### PR TITLE
clean up inconsistencies with reshaping and axes when fitting

### DIFF
--- a/contsub/image_plane.py
+++ b/contsub/image_plane.py
@@ -44,8 +44,7 @@ class ContSub():
         else:
             dimx, dimy, nchan = cube.shape
             
-        contx = np.zeros_like(cube)
-        line = np.zeros_like(cube)
+        cont_model = np.zeros_like(cube)
         nomask = self.nomask
         if nomask:
             mask = None
@@ -68,7 +67,7 @@ class ContSub():
                 nanvals_idx = np.where(np.isnan(cube_ij))
                 nansize = len(nanvals_idx[0])
                 if nansize == nchan:
-                    contx[slc] = np.full_like(cube_ij, np.nan)
+                    cont_model[slc] = np.full_like(cube_ij, np.nan)
                     continue
                 elif nansize > 0:
                     if nomask:
@@ -80,16 +79,15 @@ class ContSub():
                     if isinstance(mask_ij, np.ndarray) and \
                             (nchan - mask_ij.sum()) / nchan > self.fit_tol/100:
                         skipped_lines += 1
-                        contx[slc] = np.full_like(cube_ij, np.nan)
+                        cont_model[slc] = np.full_like(cube_ij, np.nan)
                         continue
                 
-                contx[slc] = fitfunc.fit(xspec, cube_ij, 
+                cont_model[slc] = fitfunc.fit(xspec, cube_ij, 
                                                 weights = mask_ij)
         
-        line = cube - contx
             
         if skipped_lines > 0:
             log.info(f"This worker set {skipped_lines} spectra to NaN because of --cont-fit-tol.")
             
-        return contx, line
+        return cont_model
     

--- a/contsub/parser/imcontsub.py
+++ b/contsub/parser/imcontsub.py
@@ -10,7 +10,7 @@ from scabha import init_logger
 from contsub.image_plane import ContSub
 from contsub.fitfuncs import FitBSpline
 import astropy.io.fits as fitsio
-from contsub.utils import zds_from_fits, get_automask
+from contsub.utils import zds_from_fits, get_automask, subtract_fits
 import dask.array as da
 import time
 import numpy as np
@@ -91,8 +91,8 @@ def runit(**kwargs):
         allow_rechunk=True,
     )
 
-    signature = f"(spectral),({dims_string}),({dims_string}) -> (spectral,dec,ra),(spectral,dec,ra)"
-    meta = np.ndarray((), cube.dtype), np.ndarray((), cube.dtype)
+    signature = f"(spectral),({dims_string}),({dims_string}) -> ({dims_string})"
+    meta = (np.ndarray((), cube.dtype),)
     xspec = zds.FREQS.data
     
     dask.config.set(scheduler='threads', num_workers = opts.nworkers)
@@ -129,30 +129,21 @@ def runit(**kwargs):
                 dblock,
                 mask_future,
             ))
-        
-        results = da.compute(futures)
-        
-        continuum = np.concatenate(
-            [ results[0][chunk_][0] for chunk_ in range(biter+1)],
-        ).transpose((2,1,0))
-        
-        
-        line = np.concatenate(
-            [ results[0][chunk_][1] for chunk_ in range(biter+1)],
-        ).transpose((2,1,0))
-        
-    header = zds.attrs["header"]
-    
-    log.info("Writing outputs") 
+             
+        continuum = da.concatenate(futures).transpose((2,1,0))
     
     if has_stokes:
         continuum = continuum[np.newaxis,...]
-        line = line[np.newaxis,...]
+        
+    header = zds.attrs["header"]
+    out_ds_cont = fitsio.PrimaryHDU(continuum, header=header)
     
-    log.info(f"Writing fitted continuum data to: {outcont}")
-    fitsio.writeto(outcont, continuum, header, overwrite=opts.overwrite)
+    out_ds_cont.writeto(outcont, overwrite=opts.overwrite)
+    log.info(f"Continuum model cube written to: {outcont}")
+    
+    out_ds_line = subtract_fits(infits, outcont, chunks={0: opts.ra_chunks, 1:None, 2:None})
     log.info(f"Writing residual data (line cube) to: {outline}")
-    fitsio.writeto(outline, line, header, overwrite=opts.overwrite)
+    out_ds_line.writeto(outline, overwrite=opts.overwrite)
 
     # DONE
     dtime = time.time() - start_time

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "contsub"
-version = "1.0.1"
+version = "1.0.2"
 description = "Radio astronomy data continuum subtraction tools"
 authors = ["Amir Kazemi-Moridani, Sphesihle Makhathini, Mika Naidoo"]
 license = "MIT"
@@ -16,7 +16,6 @@ numpy = "^1.22.4"
 astropy = "^6.0.0"
 scipy = "^1.12.0"
 xarray-fits = "*"
-zarr = "^2.18"
 stimela = "^2.1.2"
 
 


### PR DESCRIPTION
- Remove inconsistencies between input, defined and output dimensions of cubes. 
- Only return the continuum model, write it to disc, and then compute the residual between the disc-stored data and the continuum model. 
- Getting the residual/line cube this way is faster than computing residuals at the same time as the continuum model.