### PR TITLE
return FREQ data only if requested

### DIFF
--- a/contsub/fitfuncs.py
+++ b/contsub/fitfuncs.py
@@ -79,7 +79,6 @@ class FitBSpline(FitFunc):
         chwid = (nchan // self.imax) // 8
         knots = lambda: self.rng.integers(-chwid, chwid, size = knotind.shape)+knotind
         
-        
         splCfs = splrep(x, data, task = -1, w = weights, t = x[knots()], k = self.order)
         spl = splev(x, splCfs)
         return spl

--- a/contsub/parser/imcontsub.py
+++ b/contsub/parser/imcontsub.py
@@ -38,7 +38,7 @@ def runit(**kwargs):
         log.warning("Requested --cont-fit-tol is larger than 100 percent. Assuming it is 100.")
         opts.cont_fit_tol = 100
         
-    infits = opts.input_image
+    infits = File(opts.input_image)
     
     if opts.output_prefix:
         prefix = opts.output_prefix
@@ -47,13 +47,24 @@ def runit(**kwargs):
     
     outcont = File(f"{prefix}-cont.fits")
     outline = File(f"{prefix}-line.fits")
+    
     if opts.overwrite is False and (outcont.EXISTS or outline.EXISTS):
         raise RuntimeError("At least one output file exists, but --no-overwrite has been set. Unset it to proceed.")
+
+    if opts.segments is None:
+        raise RuntimeError("Required option 'segments' is not set. Please run 'imcontsub --help' for more information.")
+        
+    if len(opts.order) != len(opts.segments):
+        raise ValueError("If setting multiple --order and --segments, they must be of equal length. "
+                    f"Got {len(opts.order)} orders and {len(opts.segments)} segments.")
+    niter = len(opts.order)
+
+
     
     chunks = dict(ra = opts.ra_chunks or 64, dec=None, spectral=None)
     
     rest_freq = opts.rest_freq
-    zds = zds_from_fits(infits, chunks=chunks, rest_freq=rest_freq, hdu_idx=opts.hdu_index, add_freqs=True)
+    zds = zds_from_fits(infits.PATH, chunks=chunks, rest_freq=rest_freq, hdu_idx=opts.hdu_index, add_freqs=True)
     base_dims = ["ra", "dec", "spectral", "stokes"]
     if not hasattr(zds, "stokes"):
         base_dims.remove("stokes")
@@ -70,10 +81,6 @@ def runit(**kwargs):
     else:
         cube = zds.DATA
     
-    if len(opts.order) != len(opts.segments):
-        raise ValueError("If setting multiple --order and --segments, they must be of equal length. "
-                    f"Got {len(opts.order)} orders and {len(opts.segments)} segments.")
-    niter = len(opts.order)
     
     nomask = True
     automask = False 

--- a/contsub/parser/imcontsub.py
+++ b/contsub/parser/imcontsub.py
@@ -56,7 +56,7 @@ def runit(**kwargs):
     chunks = dict(ra = opts.ra_chunks or 64, dec=None, spectral=None)
     
     rest_freq = opts.rest_freq
-    zds = zds_from_fits(infits, chunks=chunks, rest_freq=rest_freq, hdu_idx=opts.hdu_index)
+    zds = zds_from_fits(infits, chunks=chunks, rest_freq=rest_freq, hdu_idx=opts.hdu_index, add_freqs=True)
     base_dims = ["ra", "dec", "spectral", "stokes"]
     if not hasattr(zds, "stokes"):
         base_dims.remove("stokes")

--- a/contsub/parser/imcontsub.py
+++ b/contsub/parser/imcontsub.py
@@ -38,7 +38,7 @@ def runit(**kwargs):
         log.warning("Requested --cont-fit-tol is larger than 100 percent. Assuming it is 100.")
         opts.cont_fit_tol = 100
         
-    infits = File(opts.input_image)
+    infits = opts.input_image
     
     if opts.output_prefix:
         prefix = opts.output_prefix
@@ -49,9 +49,6 @@ def runit(**kwargs):
     outline = File(f"{prefix}-line.fits")
     if opts.overwrite is False and (outcont.EXISTS or outline.EXISTS):
         raise RuntimeError("At least one output file exists, but --no-overwrite has been set. Unset it to proceed.")
-    
-    if not infits.EXISTS:
-        raise FileNotFoundError(f"Input FITS image could not be found at: {infits.PATH}")
     
     chunks = dict(ra = opts.ra_chunks or 64, dec=None, spectral=None)
     

--- a/contsub/parser/imcontsub.yaml
+++ b/contsub/parser/imcontsub.yaml
@@ -24,10 +24,6 @@ inputs:
     dtype: List[float]
     policies:
       repeat: "[]"
-    default:
-    - 5
-    - 4
-    - 3
   automask-per-iter:
     info: Generate a new mask per iteration.
     dtype: bool

--- a/contsub/parser/library/spline.yaml
+++ b/contsub/parser/library/spline.yaml
@@ -4,18 +4,11 @@ inputs:
     dtype: List[int]
     policies:
       repeat: "[]"
-    default:
-    - 3
-    - 3
-    - 3
+    default: 3
   segments: 
     info: Width of spline segments in km/s. If given as a list, then it must have same sixe as --order.
     dtype: List[float]
     policies:
       repeat: "[]"
-    default:
-    - 1750
-    - 1675
-    - 1500
 outputs:
   {}

--- a/contsub/utils.py
+++ b/contsub/utils.py
@@ -43,7 +43,7 @@ def get_automask(xspec, cube, sigma_clip=5, order=3, segments=400):
     return mask
 
 
-def zds_from_fits(fname, chunks=None, rest_freq=None, hdu_idx=0):
+def zds_from_fits(fname, chunks=None, rest_freq=None, hdu_idx=0, add_freqs=False):
     """ Creates Zarr store from a FITS file. The resulting array has 
     dimensions = RA, DEC, SPECTRAL[, STOKES]
 
@@ -63,7 +63,7 @@ def zds_from_fits(fname, chunks=None, rest_freq=None, hdu_idx=0):
     
     header = fds.hdu.header
     if rest_freq:
-        header["RESTFRQ"] = rest_freq * 1e6 # set it to Hz
+        header["RESTFREQ"] = rest_freq * 1e6 # set it to Hz
     wcs = WCS(header, naxis="spectral stokes".split())
     
 
@@ -78,11 +78,17 @@ def zds_from_fits(fname, chunks=None, rest_freq=None, hdu_idx=0):
         new_names.append("stokes")
 
     coords = dict([(a,fds.hdu[b].values) for a,b in zip(new_names,axis_names)])
+    if add_freqs:
+        data_vars = {
+            "DATA": (new_names, fds_xyz.data),
+            "FREQS": (("spectral",), FitsHeader(header).retFreq()), 
+        }
+    else:
+        data_vars = {
+            "DATA" : (new_names, fds_xyz.data),
+        }
     ds = xr.Dataset(
-        data_vars = dict(
-            DATA = (new_names, fds_xyz.data),
-            FREQS = (("spectral",), FitsHeader(header).retFreq()), 
-            ),
+        data_vars,
         coords = coords,
         attrs = dict(
             info =f"Temporary copy of data from FITS file: {fname}",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "contsub"
-version = "1.0.4"
+version = "1.0.5"
 description = "Radio astronomy data continuum subtraction tools"
 authors = ["Amir Kazemi-Moridani, Sphesihle Makhathini, Mika Naidoo"]
 license = "MIT"


### PR DESCRIPTION
Don't create a `FREQ` dataset (zds_from_fits) when reading the mask because the mask doesn't need to have a 'RESTFREQ' which is required for freq <-> velocity conversions. 