### PR TITLE
Revise README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,6 +29,28 @@ Latest (in development)
 
     pip install git+https://github.com/laduma-dev/mowjsub.git
 
+
+Using uv (Recommended development install)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+The package requires Python >=3.11, so uv is the recommended way to install
+from a local clone. If you do not have `uv <https://docs.astral.sh/uv/>`_ installed, install it first:
+
+.. code-block:: bash
+
+    pip install uv
+
+Then clone the repository, navigate into it, activate your existing virtual
+environment, and sync dependencies:
+
+.. code-block:: bash
+
+    git clone https://github.com/laduma-dev/mowjsub.git
+    cd mowjsub
+
+    source /path/to/your/.venv/bin/activate
+
+    uv sync --python 3.12 --active #NOTE: --active ensures the package is installed in your activated virtual environment
+
 The full documentation is available on `readthedocs <https://contsub.readthedocs.io/>`_.
 
 

--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,10 @@ environment, and sync dependencies:
 
     source /path/to/your/.venv/bin/activate
 
-    uv sync --python 3.12 --active #NOTE: --active ensures the package is installed in your activated virtual environment
+    uv sync --python 3.12 --active 
+.. note::
+
+    ``--active`` ensures the package is installed in your activated virtual environment.
 
 The full documentation is available on `readthedocs <https://contsub.readthedocs.io/>`_.
 


### PR DESCRIPTION
Updated installation instructions for using uv since package requires python 3.11 or greater and poetry doesn't support > versions