### PR TITLE
Fix chans_in_velwidth reference frequency, and the test_b_spline flake

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,6 +37,29 @@ project's former name, **contsub**.
 
 ### Fixed
 
+- **`chans_in_velwidth` reference frequency and rounding.** A channel's velocity
+  width is `dv = c·df/f`, so it varies as 1/f across the band; the reference
+  frequency is now stated explicitly as the band centre instead of being implied
+  by an average of two edge estimates. Three real defects went with that: the
+  upper edge was selected with `np.partition(freqs, 2)[-2:]`, which does **not**
+  return the two largest elements (partition only guarantees position `kth`) and
+  silently picked arbitrary channels on any grid that was not already sorted;
+  the channel count was truncated with `int()` rather than rounded, biasing every
+  conversion downwards by up to a full channel; and `c` was the rounded
+  `2.998e8` instead of the exact value already defined in `doppler.py`.
+
+  **This changes results.** On a 1000-channel L-band grid, 300 km/s now converts
+  to 210 channels where it previously gave 209 (the true value is 209.82).
+  Continuum fits using `--velwidth` will differ slightly from 2.0rc1.
+- **`test_b_spline`'s flaky tolerance.** `FitBSpline` jitters its knots by up to
+  ±25 channels, and the test compared two independently-seeded fitters, so the
+  assertion was measuring knot placement rather than the velwidth/chanwidth
+  equivalence it claimed to test. The residual MAD reached ~0.05 on roughly 8%
+  of datasets, which is why the tolerance had been raised repeatedly. `FitFunc`
+  now takes an optional `seed`; with knots held fixed the two paths agree
+  *exactly*, so the test asserts equality instead of a tolerance. Verified over
+  40 fresh random datasets. Default behaviour is unchanged — `seed=None` still
+  draws fresh entropy.
 - **Image-plane out-of-memory failures**, along with fitters that mutated their
   input arrays. The median-filter options are now wired through to the CLI.
 - Dead DCT references and stale parser imports removed; the `nworkers`

--- a/src/mowjsub/fitfuncs.py
+++ b/src/mowjsub/fitfuncs.py
@@ -23,12 +23,17 @@ class FitFunc:
         chanwidth: int = None,
         fit_lam: int = None,
         fit_tol: float = 0,
+        seed=None,
     ):
         """
 
         Args:
             order (_type_): _description_
             velwidth (_type_): _description_
+            seed: Seed for fitters that place knots at random offsets. None
+                (the default) draws fresh entropy, so repeated fits of the same
+                spectrum differ slightly. Pass an integer to make a run
+                reproducible.
         """
         self.velwidth = velwidth
         self.fit_tol = fit_tol
@@ -38,6 +43,7 @@ class FitFunc:
         self.preped = False
         self.chanwidth = chanwidth
         self.fit_lam = fit_lam
+        self.seed = seed
 
     def invalid_point_count(self, data: np.ndarray, mask: np.ndarray):
         """Calculates the number of invalid data points in a spectrum.
@@ -99,8 +105,7 @@ class FitBSpline(FitFunc):
         self.max_spline_order = int(self.nchan / self.chanwidth) + 1
         log.info(f"max spline order: {self.max_spline_order}")
 
-        rs = np.random.SeedSequence()
-        self.rng = np.random.default_rng(rs)
+        self.rng = np.random.default_rng(np.random.SeedSequence(self.seed))
         self.preped = True
 
     def fit(self, data: np.ndarray, mask: np.ndarray, weights: np.ndarray):

--- a/src/mowjsub/utils.py
+++ b/src/mowjsub/utils.py
@@ -19,6 +19,7 @@ from xarrayfits import xds_from_fits
 from mowjsub import BIN
 from mowjsub.doppler import (
     FRAME_CODES,
+    C,
     common_channel_grid,
     doppler_factors,
     grid_frequencies,
@@ -63,19 +64,31 @@ def chans_in_velwidth(freqs: np.ndarray, velwidth: float):
     """
     Calculates the number of channels in given velocity width
 
+    A channel's velocity width is dv = c * df / f, so it varies as 1/f across
+    the band -- 0.4% end to end over a typical L-band cube. The reference
+    frequency is therefore stated explicitly, as the band centre, rather than
+    left implied by whichever channels happen to get sampled.
+
     Args:
-        freqs (np.ndarray): Frequency grid in Hz.
+        freqs (np.ndarray): Frequency grid in Hz. Need not be sorted.
         velwidth (float): Velocity width in m/s
+
+    Returns:
+        int: Channel count, at least 1.
     """
-    speed_c = 2.998e8
-    df_low = np.partition(freqs, 2)[:2]
-    df_high = np.partition(freqs, 2)[-2:]
+    freqs = np.sort(np.asarray(freqs, dtype=float))
 
-    dv_high = np.abs(np.diff(df_low) / np.mean(df_low)) * speed_c
-    dv_low = np.abs(np.diff(df_high) / np.mean(df_high)) * speed_c
-    dv = np.mean([dv_low, dv_high])
+    # Mean spacing rather than a single pair: tolerates the slightly uneven
+    # grids that come out of regridding, and does not depend on which two
+    # channels are picked.
+    df = np.abs(np.diff(freqs)).mean()
+    f_ref = 0.5 * (freqs[0] + freqs[-1])
+    dv = df / f_ref * C
 
-    return int(velwidth / dv)
+    # Round, don't truncate. Truncating biases every conversion downwards by up
+    # to a full channel -- 300 km/s on the test grid lands on 209.82 channels,
+    # which int() turned into 209.
+    return max(1, int(round(velwidth / dv)))
 
 
 def zds_from_fits(fname, chunks=None, rest_freq=None, hdu_idx=0, add_freqs=False):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -57,6 +57,8 @@ class TestFitsFunc(unittest.TestCase):
 
         self.velwidth = 300
         self.chanwidth = utils.chans_in_velwidth(freqs * 1e6, self.velwidth * 1e3)
+        # Fixed knot seed, so a fit is reproducible within a test.
+        self.seed = 20260726
 
     def test_median_filter(self):
         baseline_func = FitMedFilter(self.freqs, velwidth=self.velwidth)
@@ -82,11 +84,16 @@ class TestFitsFunc(unittest.TestCase):
         assert baseline.shape == self.data.shape
 
     def test_b_spline(self):
-        baseline_func = FitBSpline(self.freqs, order=3, velwidth=self.velwidth)
+        # Both fitters get the same seed. FitBSpline jitters its knots by up to
+        # +/-25 channels, so without this the two fits differ by knot placement
+        # rather than by anything the test is asking about -- which is what kept
+        # pushing this tolerance up: the residual MAD ran to ~0.05 on ~8% of
+        # datasets, failing whichever CI matrix entry drew one.
+        baseline_func = FitBSpline(self.freqs, order=3, velwidth=self.velwidth, seed=self.seed)
         baseline_vel = baseline_func.fit(self.data, mask=self.mask, weights=None)
 
         # test if chanwidth gives same result as velwidth
-        baseline_func = FitBSpline(self.freqs, order=3, chanwidth=self.chanwidth)
+        baseline_func = FitBSpline(self.freqs, order=3, chanwidth=self.chanwidth, seed=self.seed)
         baseline_chan = baseline_func.fit(self.data, mask=self.mask, weights=None)
 
         assert baseline_chan.shape == self.data.shape
@@ -95,7 +102,11 @@ class TestFitsFunc(unittest.TestCase):
         resid_median = np.median(resid)
         mad = np.median(np.abs(resid - resid_median))
 
-        assert mad < 5e-2
+        # With knots held fixed the two paths must agree exactly: velwidth is
+        # converted by the same `chans_in_velwidth` the test used to derive
+        # chanwidth, so this is an equality check, not a tolerance.
+        np.testing.assert_array_equal(baseline_chan, baseline_vel)
+        assert mad == 0.0
 
     def test_gcv_spline(self):
         baseline_func = FitGCVSpline(self.freqs)


### PR DESCRIPTION
Two problems that were being conflated. The tolerance in `test_b_spline` keeps needing to be raised, and the velwidth/chanwidth conversion has real defects — but they turn out to be independent, and only the second one is what the tolerance was tracking.

## `chans_in_velwidth`

Three defects in `src/mowjsub/utils.py`:

1. **The upper band edge was selected incorrectly.** `np.partition(freqs, 2)[-2:]` does *not* return the two largest elements — `np.partition` only guarantees the element at `kth` lands in its sorted position, and everything after it is in arbitrary order. On a sorted grid it worked by luck; on a shuffled copy of the very grid the tests use, it returns the wrong channels.
2. **Truncation instead of rounding.** `int(velwidth / dv)` biased every conversion downwards by up to a full channel.
3. **`c` was `2.998e8`**, while `doppler.py` already defines the exact value.

Since `dv = c·df/f` varies as 1/f across the band (~0.4% end to end over L-band), the reference frequency is now stated explicitly as the band centre rather than implied by averaging two edge estimates. Spacing is the mean channel separation, so slightly uneven regridded grids are handled.

> [!IMPORTANT]
> **This changes results.** On a 1000-channel L-band grid, 300 km/s now converts to **210** channels where it previously gave 209. The true value is 209.82. Continuum fits driven by `--velwidth` will differ slightly from 2.0rc1.

## `test_b_spline`

The tolerance was not measuring the velwidth/chanwidth equivalence the test claims to check. `FitBSpline` jitters its knots by up to ±25 channels from a fresh `SeedSequence()` per instance, and the test constructs two independent fitters — so it was comparing knot placements.

Measured, rather than assumed:

| configuration | residual MAD |
|---|---|
| same chanwidth, knots forced identical | **exactly 0.0** |
| chanwidth off by one (209 vs 210), knots identical | **exactly 0.0** — `max_spline_order` is 5 either way, so the test cannot even see a 1-channel conversion error |
| same chanwidth, knots random (what the test did) | 0.0036 – 0.0520, over the 0.05 threshold on **~8% of datasets** |

That 8% is what kept pushing the tolerance up, and it is what reddened `build (3.11)` on #39 — an unrelated sphinx-click bump.

`FitFunc` now takes an optional `seed`. The test pins it and asserts **exact equality** instead of a tolerance. `seed=None` remains the default, so production behaviour is unchanged.

## Verification

- `test_b_spline`: **0 failures over 40 fresh random datasets** (was ~8%)
- Full suite: 37 passed, 1 skipped
- `ruff check` and `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)