### PR TITLE
Make the Doppler correction placeable after continuum subtraction

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-`mowjsub` is a Python library for radio astronomy continuum subtraction, supporting both image-plane (FITS cubes) and visibility-plane (Measurement Set) workflows. It exposes two CLI entry points: `im-mowjsub` and `vis-mowjsub`.
+`mowjsub` is a Python library for radio astronomy continuum subtraction, supporting both image-plane (FITS cubes) and visibility-plane (Measurement Set) workflows. It exposes three CLI entry points: `im-mowjsub`, `vis-mowjsub` and `doppler-mowjsub`.
 
 ## Commands
 
@@ -34,6 +34,9 @@ uv run im-mowjsub <input.fits> [options]
 
 # Run the visibility-plane CLI
 uv run vis-mowjsub [options]
+
+# Run the standalone Doppler-correction CLI
+uv run doppler-mowjsub <input.ms> [options]
 ```
 
 The repo ships a tracked pre-commit hook at `.githooks/pre-commit`, enabled per clone with `git config core.hooksPath .githooks`. It runs `ruff check` and `ruff format --check` over the staged Python files, check-only — it never rewrites a file mid-commit. It uses whatever ruff `uv run` resolves, so it agrees with `uv run ruff check src/mowjsub/` by construction. Bypass with `git commit --no-verify`. There is no `pre-commit` framework dependency; don't reintroduce one.
@@ -48,7 +51,7 @@ Linting config is in `ruff.toml`: line length 180, target Python 3.11, isort ena
 
 ## Architecture
 
-### Two processing pipelines
+### Processing pipelines
 
 **Image plane** (`im-mowjsub`): Operates on FITS spectral cubes. Loads the cube via `xarray-fits` into an `xr.Dataset` with dims `[ra, dec, spectral]`, chunks along RA using Dask, fits a continuum baseline per-pixel per-spectrum, and writes two FITS outputs: `*-cont.fits` (continuum model) and `*-line.fits` (residual). Entry point: `mowjsub/parser/im_mowjsub.py:runit`.
 
@@ -58,12 +61,26 @@ Linting config is in `ruff.toml`: line length 180, target Python 3.11, isort ena
 
 `--doppler-frame` resamples the continuum-subtracted visibilities onto a channel grid fixed in a chosen spectral frame, replacing the `regridms=True` half of a CASA `mstransform` pass. `doppler.py` is pure NumPy/astropy: frame apex velocities, per-timestamp conversion factors, common-grid derivation, and channel resampling. The dask orchestration and MS I/O live in `utils.py` (`doppler_regrid_dataset`, `finalise_regridded_ms`, `observatory_location`).
 
+The correction is reachable three ways, and the differences are physical, not cosmetic:
+
+- `vis-mowjsub --doppler-frame` — fused into a contsub run, one pass.
+- `doppler-mowjsub` — the same correction standalone, over an already-subtracted MS (`parser/doppler_mowjsub.py`). Reuses `doppler_regrid_dataset`/`finalise_regridded_ms` unchanged and does no fitting. Exists so a pipeline can separate the two stages without the regrid landing first.
+- `im-mowjsub --doppler-frame` — image plane, via `plan_cube_doppler`/`apply_cube_doppler` in `utils.py` and `resample_cube` in `doppler.py`.
+
+The first two apply **one factor per timestamp**. The image-plane path cannot: a cube has already been integrated over time, so it gets a single factor and the intra-track smearing is unrecoverable. It is safe only when the drift over the observation is much smaller than a channel — `--doppler-obs-duration` makes that check explicit and warns past a tenth of a channel. Do not present the three as interchangeable.
+
+`doppler_regrid_dataset` requires a topocentric input grid (`require_topocentric`, checked against `SPECTRAL_WINDOW::MEAS_FREQ_REF`), so an MS that `mstransform` already regridded is refused rather than corrected twice.
+
+Two traps in the image-plane path: `FitsHeader.retFreq()` returns **MHz** while `parse_channel_grid` returns **Hz**, so cube frequencies are converted before touching `doppler.py`; and `retFreq` goes through astropy's high-level WCS, which needs a usable obstime even to convert pixels to frequencies, so `plan_cube_doppler` resolves the epoch first and stamps it into the header copy it passes on. `FITS_SPECSYS` (FITS keyword names) and `FRAME_CODES` (MS integer codes) describe the same frames for different formats and must not be substituted for one another.
+
 Constants and the composition of conversion steps are taken from casacore's `MeasTable`/`MCFrequency`, so grids agree with CASA. Two details are load-bearing:
 
 - The topocentric-to-barycentric step is a **plain Newtonian projection** of the observer's velocity, *not* astropy's `radial_velocity_correction`. The latter carries relativistic terms casacore omits and would offset results from CASA by ~4.7 m/s. `tests/test_doppler.py::TestCasacoreAgreement` pins this against casacore's own measures engine (it skips unless casacore measures data is installed).
 - The fit happens on the native topocentric grid and only the residual is regridded — the opposite order to `mstransform`. The continuum structure being modelled is stationary in topocentric frequency.
 
 Since the channel count changes, this path requires `--output-ms`.
+
+`vis-mowjsub --output-column` is deliberately **required with no default**. It used to default to `LINE_DATA`, which is not an MS-standard column name; don't reintroduce a default. The same reasoning makes both `--input-column` and `--output-column` required on `doppler-mowjsub` — an MS written by `vis-mowjsub --output-ms` contains no `DATA` column at all (`output_ms_dataset` drops `CHANNEL_COLUMNS` and re-adds only what the caller passes), while an in-place run leaves `DATA` holding the raw visibilities, so any default is wrong in one of the two cases. Writing the input column back in place is refused.
 
 ### Writing a new MS
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,52 @@ project's former name, **contsub**.
 
 ## Unreleased (2.0rc2)
 
+### Changed
+
+- **`vis-mowjsub --output-column` no longer defaults to `LINE_DATA`.** It is now
+  required. `LINE_DATA` is not an MS-standard column name, and defaulting to it
+  pushed a non-standard name into every tool downstream of the result. There is
+  no standard name for continuum-subtracted visibilities, so mowjsub no longer
+  invents one; pass `--output-column DATA` for the common case of feeding an
+  imager directly. This is a breaking CLI change, taken during the 2.0 release
+  candidates rather than after.
+
+  Dropping the default exposed a hazard it had been hiding: without
+  `--output-ms` the residual is written back into the input MS, so
+  `--output-column DATA` there would overwrite the visibilities the fit was made
+  from. That combination is now refused.
+
+- **An already-regridded MS is refused rather than corrected twice.**
+  `doppler_regrid_dataset` checks `SPECTRAL_WINDOW::MEAS_FREQ_REF` and requires a
+  topocentric input grid. This closes a live hole in `vis-mowjsub
+  --doppler-frame`, which would previously have applied the frame conversion on
+  top of one CASA `mstransform` had already applied.
+
 ### Added
+
+- **`doppler-mowjsub`, the Doppler correction as a standalone command.** The same
+  `--doppler-*` parameters `vis-mowjsub` takes, over an MS whose continuum has
+  already been subtracted. This lets a pipeline run continuum subtraction and the
+  frame transformation as separate stages while keeping them in the right order —
+  previously the correction was only reachable *through* a contsub run, so a
+  workflow that wanted the two separate had to run the regrid elsewhere, and if
+  it landed first the continuum was then fitted across an interpolated grid.
+  `vis-mowjsub --doppler-frame` is unchanged and remains the convenient default;
+  `tests/test_doppler.py::TestStandaloneDoppler::test_matches_the_fused_single_pass`
+  pins the two against each other.
+
+- **`im-mowjsub --doppler-frame`, Doppler correction in the image plane.**
+  Applied to both output cubes after the fit, so it is one interpolation at the
+  very end and nothing downstream inherits a correlated channel grid. The catch is
+  physical, not implementational: the Doppler factor is time-dependent, and a cube
+  has already been integrated over time, so only a single factor can be applied
+  and the intra-track smearing is unrecoverable. Safe when the drift over the
+  observation is much smaller than a channel; `--doppler-obs-duration` makes
+  mowjsub compute the drift, log it against the channel width and warn past a
+  tenth of a channel. Unambiguously right for placing several observations on one
+  grid for stacking, which is a pure shift per cube. Cube metadata is resolved
+  from the header with `--doppler-time`, `--doppler-telescope` and
+  `--doppler-phase-centre` as overrides. Requires the spectral axis on `NAXIS3`.
 
 - **Doppler correction for the visibility plane.** `--doppler-frame` resamples
   continuum-subtracted visibilities onto a channel grid fixed in a chosen

--- a/docs/source/how-to/usage.rst
+++ b/docs/source/how-to/usage.rst
@@ -66,12 +66,15 @@ Setting ``--doppler-frame`` makes :command:`vis-mowjsub` do that resampling itse
                 --fit-model b-spline \
                 --order 3 \
                 --vel-width 250 \
+                --output-column DATA \
                 --doppler-frame bary \
                 --output-ms line.ms
 
 The continuum is always fitted **before** the regrid, on the native topocentric grid. This is deliberate: the bandpass and standing-wave structure the fit is modelling is stationary in topocentric frequency, and fitting first also means the fit sees channels whose noise is still uncorrelated. Only the residual is moved onto the Doppler-corrected grid. Note that this ordering differs from CASA ``mstransform``, which regrids before it subtracts.
 
-Because the output channel grid differs from the input one, ``--doppler-frame`` requires ``--output-ms``; the result cannot be written back into a column of the input MS. The new MS carries the regridded line data in ``--output-column``, together with a ``SPECTRAL_WINDOW`` describing the new grid and its reference frame. Pass ``--output-column DATA`` if the imager you feed it to expects that column.
+Because the output channel grid differs from the input one, ``--doppler-frame`` requires ``--output-ms``; the result cannot be written back into a column of the input MS. The new MS carries the regridded line data in ``--output-column``, together with a ``SPECTRAL_WINDOW`` describing the new grid and its reference frame.
+
+``--output-column`` is required and has no default: there is no standard MS column name for continuum-subtracted visibilities, so mowjsub does not invent one. ``DATA`` is usually the right answer when the result goes straight to an imager. Note that without ``--output-ms`` the column is written back into the input MS, so naming the column you are reading is refused rather than allowed to destroy it.
 
 Available frames are ``topo``, ``geo``, ``bary``, ``lsrk``, ``lsrd``, ``galacto``, ``lgroup``, ``cmb`` and ``source``, matching the options CASA accepts. ``bary`` and ``lsrk`` are the usual choices for extragalactic and Galactic HI respectively. The frame velocities and the way conversion steps are composed follow casacore, so the grids agree with CASA's to well under 0.1 m/s. ``source`` additionally needs a systemic velocity, taken from the MS ``SOURCE::SYSVEL`` column or from ``--doppler-source-vel`` in km/s.
 
@@ -80,6 +83,7 @@ By default (``--doppler-chan-grid auto``) the output grid is derived from the ob
 .. code-block:: bash
 
     vis-mowjsub input.ms \
+                --output-column DATA \
                 --doppler-frame bary \
                 --doppler-chan-grid '1000,1419.5MHz,26.1kHz' \
                 --output-ms line.ms
@@ -89,3 +93,68 @@ The grid is given as ``nchan,chan0,chanwidth``; both frequencies need a unit (``
 Resampling uses nearest-neighbour by default, which is what caracal asks of ``mstransform`` and which leaves the noise in neighbouring channels uncorrelated. ``--doppler-interpolation linear`` is smoother but correlates adjacent channels. In either case an output channel is flagged if it falls outside the observed band at that timestamp or if any input channel feeding it is flagged, and the output weights follow from propagating the input variances through the interpolation.
 
 
+
+Doppler correction as a separate step
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+:command:`vis-mowjsub --doppler-frame` fuses the two operations into one pass, which is convenient but forces a pipeline to reach the correction *through* a continuum subtraction. :command:`doppler-mowjsub` exposes the same correction on its own, over an MS whose continuum has already gone:
+
+.. code-block:: bash
+
+    doppler-mowjsub line.ms \
+                --input-column LINE_DATA \
+                --output-column DATA \
+                --doppler-frame bary \
+                --output-ms out.ms
+
+It takes the same ``--doppler-*`` parameters, does no fitting, and produces exactly what the fused path produces — the two are pinned against each other in the test suite. Use it when continuum subtraction and the frame transformation need to be separate pipeline stages, for instance where a workflow would otherwise run CASA ``mstransform`` after the subtraction and get the order the wrong way round.
+
+``--input-column`` and ``--output-column`` are both required. There is no standard MS column for continuum-subtracted visibilities, so the input column is whatever the subtraction stage was told to write, and guessing it is how you Doppler-correct the wrong data in silence.
+
+The input must still be on its native topocentric channel grid; an MS that has already been regridded, by ``mstransform`` or by an earlier mowjsub run, is refused rather than corrected twice. mowjsub reads ``SPECTRAL_WINDOW::MEAS_FREQ_REF`` to decide.
+
+Doppler correction in the image plane
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+:command:`im-mowjsub` also accepts ``--doppler-frame``, applied to both output cubes after the continuum fit:
+
+.. code-block:: bash
+
+    im-mowjsub cube.fits \
+               --output-prefix out \
+               --fit-model b-spline --order 3 --vel-width 250 \
+               --doppler-frame bary \
+               --doppler-obs-duration 2.5
+
+**Read this before using it.** The Doppler factor changes as the Earth turns, so the visibility-plane commands apply one factor per timestamp. A cube has already been integrated over time, so only a single factor can be applied to it. Shifting the spectral axis re-centres the line but cannot undo the smearing the drift caused while the data were being imaged — that information was destroyed by the integration.
+
+The test is a ratio:
+
+    the image-plane correction is safe when the line-of-sight velocity drifts by much less than one channel over the observation.
+
+Both quantities scale with frequency, so the ratio is the same whether you state it in km/s or kHz. Pass ``--doppler-obs-duration`` (in hours) and mowjsub computes the drift, logs it against the channel width, and warns when it exceeds a tenth of a channel. Without that option the correction is still applied, at the epoch in the header, but the check cannot be made and mowjsub says so. For a long track or a narrow channelisation, correct in the visibility plane instead.
+
+Where the image-plane path is unambiguously right is putting several observations onto one grid for stacking. That is a pure shift per cube, with no smearing penalty at all — give each run the same ``--doppler-chan-grid``.
+
+A cube carries far less metadata than an MS, so the correction is resolved from the header with explicit overrides for what it cannot supply:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Quantity
+     - Taken from
+     - Override
+   * - direction
+     - the celestial WCS reference coordinate
+     - ``--doppler-phase-centre 'RA,Dec'``
+   * - epoch
+     - ``MJD-OBS``, else ``DATE-OBS``
+     - ``--doppler-time`` (ISO or MJD)
+   * - track length
+     - nothing standard records it
+     - ``--doppler-obs-duration``
+   * - position
+     - ``OBSGEO-X/Y/Z``, else ``TELESCOP``
+     - ``--doppler-telescope``
+
+Both the continuum and line cubes are written on the corrected grid, so the pair stays recombinable, and the spectral WCS is rewritten with the new ``SPECSYS``. Stale velocity keywords (``ALTRVAL``, ``ALTRPIX``, ``VELREF``) are dropped rather than left describing the old grid. ``--doppler-frame source`` needs ``--doppler-source-vel``, since a cube has no ``SOURCE::SYSVEL`` to fall back on.
+
+The spectral axis must be ``NAXIS3``; a cube with it elsewhere is refused with a message saying so.

--- a/docs/source/how-to/usage.rst
+++ b/docs/source/how-to/usage.rst
@@ -157,4 +157,4 @@ A cube carries far less metadata than an MS, so the correction is resolved from 
 
 Both the continuum and line cubes are written on the corrected grid, so the pair stays recombinable, and the spectral WCS is rewritten with the new ``SPECSYS``. Stale velocity keywords (``ALTRVAL``, ``ALTRPIX``, ``VELREF``) are dropped rather than left describing the old grid. ``--doppler-frame source`` needs ``--doppler-source-vel``, since a cube has no ``SOURCE::SYSVEL`` to fall back on.
 
-The spectral axis must be ``NAXIS3``; a cube with it elsewhere is refused with a message saying so.
+The spectral axis must be ``NAXIS3``, i.e. the axis order must be ``RA, DEC, FREQ[, STOKES]``. A cube with STOKES on ``NAXIS3`` and FREQ on ``NAXIS4`` is refused with a message saying so, whether or not a Doppler correction was asked for -- that layout is unsupported throughout :command:`im-mowjsub`, not just here. Reorder the axes (CASA ``imtrans``) and try again.

--- a/docs/source/reference/reference.rst
+++ b/docs/source/reference/reference.rst
@@ -11,3 +11,13 @@ Reference
     :nested: full
 
 
+.. click:: mowjsub.parser.vis_mowjsub:runit
+    :prog: vis-mowjsub
+    :nested: full
+
+
+.. click:: mowjsub.parser.doppler_mowjsub:runit
+    :prog: doppler-mowjsub
+    :nested: full
+
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ packages = ["src/mowjsub"]
 [project.scripts]
 im-mowjsub = "mowjsub.parser.im_mowjsub:runit"
 vis-mowjsub = "mowjsub.parser.vis_mowjsub:runit"
+doppler-mowjsub = "mowjsub.parser.doppler_mowjsub:runit"
 
 [dependency-groups]
 # Everything needed to develop and test. `dev` is uv's default group, so a plain

--- a/src/mowjsub/__init__.py
+++ b/src/mowjsub/__init__.py
@@ -8,5 +8,6 @@ BIN = OmegaConf.create(
     {
         "im_plane": "im-mowjsub",
         "vis_plane": "vis-mowjsub",
+        "doppler_plane": "doppler-mowjsub",
     }
 )

--- a/src/mowjsub/doppler.py
+++ b/src/mowjsub/doppler.py
@@ -80,6 +80,23 @@ _CHAIN = {
     "source": (),
 }
 
+#: FITS ``SPECSYS`` names for each frame (FITS WCS Paper III, table 29).
+#: Distinct from :data:`FRAME_CODES`, which is the MS ``MEAS_FREQ_REF`` integer
+#: convention -- the two describe the same frames in different file formats and
+#: must not be substituted for one another.
+FITS_SPECSYS = {
+    "topo": "TOPOCENT",
+    "geo": "GEOCENTR",
+    "bary": "BARYCENT",
+    "lsrk": "LSRK",
+    "lsrd": "LSRD",
+    "galacto": "GALACTOC",
+    "lgroup": "LOCALGRP",
+    "cmb": "CMBDIPOL",
+    # A source-frame grid is a rest-frame grid; FITS spells that SOURCE.
+    "source": "SOURCE",
+}
+
 #: Frequency units accepted in an explicit channel-grid specification.
 _FREQ_UNITS = {"hz": 1.0, "khz": 1e3, "mhz": 1e6, "ghz": 1e9}
 
@@ -307,6 +324,54 @@ def resample_map(freqs_in, factor, freqs_out, interpolation="nearest"):
         valid = (frac >= 0.0) & (frac <= 1.0)
 
     return indices, weights, valid
+
+
+def resample_cube(data, factor, freqs_in, freqs_out, axis, interpolation="nearest"):
+    """Resample a cube along its spectral axis onto a fixed output grid.
+
+    The image-plane counterpart of :func:`regrid_rows`. A cube has already been
+    integrated over time, so a single Doppler factor applies to all of it rather
+    than one per row. Output channels the input band does not cover are set to
+    NaN, which is the image-plane equivalent of raising a flag.
+
+    Note what this cannot do: the observatory's line-of-sight velocity drifts
+    during a track, and imaging has already summed over that drift. Shifting the
+    axis afterwards re-centres the spectrum but cannot undo the smearing, so this
+    is only equivalent to :func:`regrid_rows` when the drift over the observation
+    is small compared to a channel.
+
+    Args:
+        data (np.ndarray|dask.array): Cube of any dimensionality.
+        factor (float): Doppler factor for the observation.
+        freqs_in (np.ndarray): Topocentric input channel frequencies in Hz.
+        freqs_out (np.ndarray): Output channel frequencies in Hz, in the target
+            frame.
+        axis (int): Index of the spectral axis of ``data``.
+        interpolation (str): ``'nearest'`` or ``'linear'``.
+
+    Returns:
+        np.ndarray|dask.array: ``data`` with its spectral axis replaced by
+        ``freqs_out``.
+    """
+    indices, weights, valid = resample_map(freqs_in, factor, freqs_out, interpolation)
+
+    # Broadcast per-channel vectors against the spectral axis alone.
+    shape = [1] * np.ndim(data)
+    shape[axis] = -1
+
+    # Nearest weights are all 1, so skipping the multiply there keeps a float32
+    # cube float32 instead of promoting it against float64 coefficients.
+    dtype = np.result_type(data.dtype, np.float32)
+
+    resampled = None
+    for k in range(indices.shape[1]):
+        contribution = np.take(data, indices[:, k], axis=axis)
+        if interpolation != "nearest":
+            contribution = contribution * weights[:, k].reshape(shape).astype(dtype)
+        resampled = contribution if resampled is None else resampled + contribution
+
+    # np.where rather than masked assignment, so this stays lazy under dask.
+    return np.where(valid.reshape(shape), resampled, np.nan)
 
 
 def regrid_rows(data, flags, weights, factors, freqs_in, freqs_out, interpolation="nearest"):

--- a/src/mowjsub/parser/doppler_mowjsub.py
+++ b/src/mowjsub/parser/doppler_mowjsub.py
@@ -1,0 +1,98 @@
+import glob
+import os
+import time
+
+import click
+import dask
+import dask.array as da
+from daskms import xds_from_ms, xds_to_table
+from omegaconf import OmegaConf
+from scabha import init_logger
+from scabha.basetypes import File
+from scabha.schema_utils import clickify_parameters, paramfile_loader
+from tqdm.dask import TqdmCallback
+
+import mowjsub
+from mowjsub import BIN
+from mowjsub.utils import (
+    doppler_regrid_dataset,
+    finalise_regridded_ms,
+    get_ds_from_msdsl,
+)
+
+log = init_logger(BIN.doppler_plane)
+
+command = BIN.doppler_plane
+thisdir = os.path.dirname(__file__)
+source_files = glob.glob(f"{thisdir}/library/*.yaml")
+sources = [File(item) for item in source_files]
+parserfile = File(f"{thisdir}/doppler_mowjsub.yaml")
+config = paramfile_loader(parserfile, sources)["doppler_mowjsub"]
+
+
+@click.command("doppler-mowjsub")
+@click.version_option(str(mowjsub.__version__))
+@clickify_parameters(config)
+def runit(**kwargs):
+    """Doppler-correct an MS whose continuum has already been subtracted.
+
+    This is the standalone half of what ``vis-mowjsub --doppler-frame`` does in
+    one pass. Splitting it out lets a pipeline run continuum subtraction and the
+    frame conversion as separate stages while keeping them in the right order:
+    the continuum must be fitted on the native topocentric grid, where the
+    bandpass structure it models is stationary.
+    """
+    start_time = time.time()
+
+    opts = OmegaConf.create(kwargs)
+    ms = opts.ms
+    spwid = opts.spwid
+    fieldid = opts.field_id
+    chunksize = opts.row_chunks
+    input_column = opts.input_column
+    output_column = opts.output_column
+    frame = opts.doppler_frame
+
+    ms_dsl = xds_from_ms(
+        ms,
+        index_cols=["TIME", "ANTENNA1", "ANTENNA2"],
+        group_cols=["FIELD_ID", "DATA_DESC_ID"],
+        chunks={"row": chunksize},
+    )
+
+    msds = get_ds_from_msdsl(ms_dsl, field_id=fieldid, data_desc_id=spwid)
+
+    if input_column not in msds.data_vars:
+        available = ", ".join(sorted(name for name, var in msds.data_vars.items() if "chan" in var.dims))
+        raise RuntimeError(f"Column '{input_column}' is not in {ms}. Per-channel columns it does have: {available or 'none'}.")
+
+    dask.config.set(scheduler="threads", num_workers=opts.nworkers)
+
+    source_vel = opts.doppler_source_vel
+    regrid_ds, freqs_out, chanwidth = doppler_regrid_dataset(
+        msds,
+        ms,
+        getattr(msds, input_column).data,
+        output_column,
+        spwid,
+        fieldid,
+        frame=frame,
+        chan_grid=opts.doppler_chan_grid,
+        interpolation=opts.doppler_interpolation,
+        source_vel=None if source_vel is None else source_vel * 1e3,
+    )
+
+    ms_name = str(opts.output_ms)
+    writes = [xds_to_table([regrid_ds], ms_name, columns="ALL")]
+    with TqdmCallback(desc="Writing Doppler-corrected data"):
+        da.compute(writes)
+
+    finalise_regridded_ms(ms, ms_name, spwid, freqs_out, chanwidth, frame)
+    log.info(f"Doppler correction completed. Data from '{input_column}' written to column '{output_column}' in {ms_name}.")
+
+    # DONE
+    dtime = time.time() - start_time
+    hours = int(dtime / 3600)
+    mins = dtime / 60 - hours * 60
+    secs = (mins % 1) * 60
+    log.info(f"Runtime {hours}:{int(mins)}:{secs:.1f}")

--- a/src/mowjsub/parser/doppler_mowjsub.yaml
+++ b/src/mowjsub/parser/doppler_mowjsub.yaml
@@ -1,0 +1,69 @@
+
+inputs:
+  ms:
+        info: Input MS file. Its continuum must already have been subtracted; this command does no fitting.
+        dtype: File
+        must_exist: yes
+        required: yes
+        policies:
+          positional: true
+  input-column:
+        info: "Column holding the continuum-subtracted data to Doppler-correct. Required: there is no standard MS column name for continuum-subtracted visibilities, so this is whatever the subtraction stage was told to write."
+        dtype: str
+        required: yes
+  output-column:
+        info: Column name to write the Doppler-corrected data to in the output MS. Pass DATA if the imager you feed it to expects that column.
+        dtype: str
+        required: yes
+  output-ms:
+        info: Name of the MS to write. Required, since the Doppler correction changes the channel count and so cannot be written back into a column of the input MS.
+        dtype: File
+        required: yes
+  spwid:
+        info: Spectral Window ID
+        dtype: int
+        default: 0
+  field-id:
+        info: Field ID
+        dtype: int
+        default: 0
+  row-chunks:
+        info: Chunking strategy (Done along the time axis)
+        dtype: int
+        default: 10000
+  nworkers:
+        info: "Number of parallel worker threads (roughly one per CPU core)."
+        dtype: int
+        default: 4
+  doppler-frame:
+        info: "Spectral reference frame to Doppler-correct the output to. The visibilities are resampled onto a channel grid fixed in this frame, as CASA mstransform does with regridms=True. The input channel grid must still be topocentric, i.e. as it came off the telescope."
+        dtype: str
+        required: yes
+        choices:
+            - topo
+            - geo
+            - bary
+            - lsrk
+            - lsrd
+            - galacto
+            - lgroup
+            - cmb
+            - source
+  doppler-chan-grid:
+        info: "Output channel grid for the Doppler correction. 'auto' derives the grid that every timestamp of this observation covers. Otherwise give 'nchan,chan0,chanwidth' with frequency units, e.g. '1000,1419.5MHz,26.1kHz'; use this to place several MSs on one common grid, since 'auto' only ever sees a single MS."
+        dtype: str
+        default: auto
+  doppler-interpolation:
+        info: "Interpolation used when resampling onto the Doppler-corrected grid. 'nearest' is what caracal asks of CASA mstransform and leaves channel noise uncorrelated; 'linear' is smoother but correlates adjacent channels."
+        dtype: str
+        choices:
+            - nearest
+            - linear
+        default: nearest
+  doppler-source-vel:
+        info: "Systemic radial velocity of the source in km/s, positive for recession. Only used with --doppler-frame=source; when unset it is read from the MS SOURCE::SYSVEL column."
+        dtype: float
+
+
+outputs:
+  {}

--- a/src/mowjsub/parser/im_mowjsub.py
+++ b/src/mowjsub/parser/im_mowjsub.py
@@ -24,6 +24,7 @@ from mowjsub.fitfuncs import (
 from mowjsub.image_plane import ContSub
 from mowjsub.utils import (
     apply_cube_doppler,
+    cube_spectral_axis,
     get_automask,
     plan_cube_doppler,
     subtract_fits,
@@ -79,6 +80,11 @@ def runit(**kwargs):
     ra_chunks = opts.ra_chunks
     # Zero disables chunking, i.e. the RA axis is read as a single block.
     chunks = dict(ra=ra_chunks or -1, dec=None, spectral=None)
+
+    # Check the axis order up front. zds_from_fits would otherwise reach it
+    # first and fail as a dimension clash between FREQS and DATA, which says
+    # nothing about the actual problem.
+    cube_spectral_axis(fitsio.getheader(infits.PATH, opts.hdu_index))
 
     rest_freq = opts.rest_freq
     zds = zds_from_fits(

--- a/src/mowjsub/parser/im_mowjsub.py
+++ b/src/mowjsub/parser/im_mowjsub.py
@@ -22,7 +22,13 @@ from mowjsub.fitfuncs import (
     FitPolynomial,
 )
 from mowjsub.image_plane import ContSub
-from mowjsub.utils import get_automask, subtract_fits, zds_from_fits
+from mowjsub.utils import (
+    apply_cube_doppler,
+    get_automask,
+    plan_cube_doppler,
+    subtract_fits,
+    zds_from_fits,
+)
 
 command = BIN.im_plane
 thisdir = os.path.dirname(__file__)
@@ -165,19 +171,61 @@ def runit(**kwargs):
         continuum = continuum[np.newaxis, ...]
 
     header = zds.attrs["header"]
-    out_ds_cont = fitsio.PrimaryHDU(continuum, header=header)
 
-    out_ds_cont.writeto(outcont.PATH, overwrite=opts.overwrite)
-    log.info(f"Continuum model cube written to: {outcont}")
+    if not opts.doppler_frame:
+        out_ds_cont = fitsio.PrimaryHDU(continuum, header=header)
 
-    out_ds_line = subtract_fits(
-        infits.PATH,
-        outcont.PATH,
-        hdu_idx=opts.hdu_index,
-        ra_chunks=ra_chunks,
-    )
-    log.info(f"Writing residual data (line cube) to: {outline}")
-    out_ds_line.writeto(outline.PATH, overwrite=opts.overwrite)
+        out_ds_cont.writeto(outcont.PATH, overwrite=opts.overwrite)
+        log.info(f"Continuum model cube written to: {outcont}")
+
+        out_ds_line = subtract_fits(
+            infits.PATH,
+            outcont.PATH,
+            hdu_idx=opts.hdu_index,
+            ra_chunks=ra_chunks,
+        )
+        log.info(f"Writing residual data (line cube) to: {outline}")
+        out_ds_line.writeto(outline.PATH, overwrite=opts.overwrite)
+    else:
+        # subtract_fits reads its continuum back off disk, so the topocentric
+        # model has to exist as a file before the residual can be formed. Stage
+        # it beside the outputs rather than writing outcont twice: --overwrite
+        # is checked once, against files from previous runs, so a second write
+        # to outcont would either trip that check or have to bypass it.
+        source_vel = opts.doppler_source_vel
+        plan = plan_cube_doppler(
+            header,
+            opts.doppler_frame,
+            chan_grid=opts.doppler_chan_grid,
+            obs_time=opts.doppler_time,
+            obs_duration=opts.doppler_obs_duration,
+            telescope=opts.doppler_telescope,
+            phase_centre=opts.doppler_phase_centre,
+            source_vel=None if source_vel is None else source_vel * 1e3,
+        )
+
+        scratch = File(f"{prefix}-cont-topo.fits")
+        fitsio.PrimaryHDU(continuum, header=header).writeto(scratch.PATH, overwrite=True)
+        try:
+            line_hdu = subtract_fits(
+                infits.PATH,
+                scratch.PATH,
+                hdu_idx=opts.hdu_index,
+                ra_chunks=ra_chunks,
+            )
+
+            # One plan for both cubes, so the pair stays on a single grid and
+            # remains recombinable.
+            cont_data, cont_header = apply_cube_doppler(continuum, header, plan, opts.doppler_interpolation)
+            fitsio.PrimaryHDU(cont_data, header=cont_header).writeto(outcont.PATH, overwrite=opts.overwrite)
+            log.info(f"Continuum model cube written to: {outcont}")
+
+            line_data, line_header = apply_cube_doppler(line_hdu.data, line_hdu.header, plan, opts.doppler_interpolation)
+            log.info(f"Writing residual data (line cube) to: {outline}")
+            fitsio.PrimaryHDU(line_data, header=line_header).writeto(outline.PATH, overwrite=opts.overwrite)
+        finally:
+            if os.path.exists(scratch.PATH):
+                os.remove(scratch.PATH)
 
     # DONE
     dtime = time.time() - start_time

--- a/src/mowjsub/parser/im_mowjsub.yaml
+++ b/src/mowjsub/parser/im_mowjsub.yaml
@@ -92,5 +92,44 @@ inputs:
       - trace
       - error
       - critical
+  doppler-frame:
+    info: "Spectral reference frame to Doppler-correct the output cubes to, applied after the continuum fit. A cube has already been integrated over time, so only a single correction factor can be applied: this is safe only when the line-of-sight velocity drifts by much less than one channel over the observation, and cannot undo smearing from a larger drift. Pass --doppler-obs-duration to have that checked. For long tracks, correct in the visibility plane instead (doppler-mowjsub). Leave unset to skip Doppler correction."
+    dtype: str
+    choices:
+      - topo
+      - geo
+      - bary
+      - lsrk
+      - lsrd
+      - galacto
+      - lgroup
+      - cmb
+      - source
+  doppler-chan-grid:
+    info: "Output channel grid for the Doppler correction. 'auto' derives it from this cube, dropping one guard channel at each end. Otherwise give 'nchan,chan0,chanwidth' with frequency units, e.g. '1000,1419.5MHz,26.1kHz'; use this to place several observations on one common grid for stacking."
+    dtype: str
+    default: auto
+  doppler-interpolation:
+    info: "Interpolation used when resampling onto the Doppler-corrected grid. 'nearest' leaves channel noise uncorrelated; 'linear' is smoother but correlates adjacent channels."
+    dtype: str
+    choices:
+      - nearest
+      - linear
+    default: nearest
+  doppler-source-vel:
+    info: "Systemic radial velocity of the source in km/s, positive for recession. Required with --doppler-frame=source, since a cube carries no SOURCE::SYSVEL to fall back on."
+    dtype: float
+  doppler-time:
+    info: "Observation epoch for the Doppler correction, as an ISO date or an MJD. Overrides the cube's MJD-OBS or DATE-OBS."
+    dtype: str
+  doppler-obs-duration:
+    info: "Length of the observation in hours. Only used to check how far the line-of-sight velocity drifted over the track, and to take the correction at the midpoint rather than the start. Nothing standard records this in a FITS header, so it must be given; without it the drift check is skipped."
+    dtype: float
+  doppler-telescope:
+    info: "Observatory name, resolved through astropy's site registry. Overrides the cube's OBSGEO-X/Y/Z or TELESCOP keywords, and is needed when the header carries neither."
+    dtype: str
+  doppler-phase-centre:
+    info: "Field centre used to project the observatory velocity, as 'RA,Dec' in degrees or sexagesimal. Overrides the cube's WCS reference coordinate."
+    dtype: str
 outputs:
   {}

--- a/src/mowjsub/parser/vis_mowjsub.py
+++ b/src/mowjsub/parser/vis_mowjsub.py
@@ -73,6 +73,14 @@ def runit(**kwargs):
     outchunks = dict(time=opts.time_chunks, bl_chunks=opts.bl_chunks)
     input_column = opts.input_column
     output_column = opts.output_column
+
+    # Writing back into the input MS is the one path where the output column can
+    # destroy the data the fit was made from, and it cannot be undone.
+    if output_column == input_column and not opts.output_ms:
+        raise RuntimeError(
+            f"--output-column={output_column} is the column being read, and without --output-ms the residual is written back into {ms}, "
+            f"overwriting it. Pass --output-ms to write a new MS, or choose a different --output-column."
+        )
     zarr_name = opts.load_from_cache
     cont_tol = opts.cont_fit_tol
 

--- a/src/mowjsub/parser/vis_mowjsub.yaml
+++ b/src/mowjsub/parser/vis_mowjsub.yaml
@@ -12,9 +12,9 @@ inputs:
         dtype: str
         default: DATA 
   output-column:
-        info: Column name to write the continuum subtracted data to
+        info: "Column name to write the continuum subtracted data to. Required: there is no standard MS column for continuum-subtracted visibilities, so naming one is left to you. Pass DATA if the imager you feed the result to expects that column -- but note that without --output-ms this writes back into the input MS, so it must differ from --input-column."
         dtype: str
-        default: LINE_DATA  
+        required: yes
   fit-model:
         info: "Fit function to model the continuum. The 'scipy-median-filter' model is much faster than 'median-filter', but treats band edges and masked channels differently, so the two do not give identical continuum models. WARNING: A median-filter continuum model may subsume low SNR line emission, use it with great care."
         dtype: str

--- a/src/mowjsub/stimelating/doppler_mowjsub_param.yaml
+++ b/src/mowjsub/stimelating/doppler_mowjsub_param.yaml
@@ -1,0 +1,63 @@
+ms:
+      info: Input MS file. Its continuum must already have been subtracted; this command does no fitting.
+      dtype: File
+      must_exist: yes
+      required: yes
+      policies:
+        positional: true
+input-column:
+      info: "Column holding the continuum-subtracted data to Doppler-correct. Required: there is no standard MS column name for continuum-subtracted visibilities, so this is whatever the subtraction stage was told to write."
+      dtype: str
+      required: yes
+output-column:
+      info: Column name to write the Doppler-corrected data to in the output MS. Pass DATA if the imager you feed it to expects that column.
+      dtype: str
+      required: yes
+output-ms:
+      info: Name of the MS to write. Required, since the Doppler correction changes the channel count and so cannot be written back into a column of the input MS.
+      dtype: File
+      required: yes
+spwid:
+      info: Spectral Window ID
+      dtype: int
+      default: 0
+field-id:
+      info: Field ID
+      dtype: int
+      default: 0
+row-chunks:
+      info: Chunking strategy (Done along the time axis)
+      dtype: int
+      default: 10000
+nworkers:
+      info: "Number of parallel worker threads (roughly one per CPU core)."
+      dtype: int
+      default: 4
+doppler-frame:
+      info: "Spectral reference frame to Doppler-correct the output to. The visibilities are resampled onto a channel grid fixed in this frame, as CASA mstransform does with regridms=True. The input channel grid must still be topocentric, i.e. as it came off the telescope."
+      dtype: str
+      required: yes
+      choices:
+          - topo
+          - geo
+          - bary
+          - lsrk
+          - lsrd
+          - galacto
+          - lgroup
+          - cmb
+          - source
+doppler-chan-grid:
+      info: "Output channel grid for the Doppler correction. 'auto' derives the grid that every timestamp of this observation covers. Otherwise give 'nchan,chan0,chanwidth' with frequency units, e.g. '1000,1419.5MHz,26.1kHz'; use this to place several MSs on one common grid, since 'auto' only ever sees a single MS."
+      dtype: str
+      default: auto
+doppler-interpolation:
+      info: "Interpolation used when resampling onto the Doppler-corrected grid. 'nearest' is what caracal asks of CASA mstransform and leaves channel noise uncorrelated; 'linear' is smoother but correlates adjacent channels."
+      dtype: str
+      choices:
+          - nearest
+          - linear
+      default: nearest
+doppler-source-vel:
+      info: "Systemic radial velocity of the source in km/s, positive for recession. Only used with --doppler-frame=source; when unset it is read from the MS SOURCE::SYSVEL column."
+      dtype: float

--- a/src/mowjsub/stimelating/im_mowjsub_param.yaml
+++ b/src/mowjsub/stimelating/im_mowjsub_param.yaml
@@ -91,3 +91,42 @@ loglevel:
     - trace
     - error
     - critical
+doppler-frame:
+  info: "Spectral reference frame to Doppler-correct the output cubes to, applied after the continuum fit. A cube has already been integrated over time, so only a single correction factor can be applied: this is safe only when the line-of-sight velocity drifts by much less than one channel over the observation, and cannot undo smearing from a larger drift. Pass --doppler-obs-duration to have that checked. For long tracks, correct in the visibility plane instead (doppler-mowjsub). Leave unset to skip Doppler correction."
+  dtype: str
+  choices:
+    - topo
+    - geo
+    - bary
+    - lsrk
+    - lsrd
+    - galacto
+    - lgroup
+    - cmb
+    - source
+doppler-chan-grid:
+  info: "Output channel grid for the Doppler correction. 'auto' derives it from this cube, dropping one guard channel at each end. Otherwise give 'nchan,chan0,chanwidth' with frequency units, e.g. '1000,1419.5MHz,26.1kHz'; use this to place several observations on one common grid for stacking."
+  dtype: str
+  default: auto
+doppler-interpolation:
+  info: "Interpolation used when resampling onto the Doppler-corrected grid. 'nearest' leaves channel noise uncorrelated; 'linear' is smoother but correlates adjacent channels."
+  dtype: str
+  choices:
+    - nearest
+    - linear
+  default: nearest
+doppler-source-vel:
+  info: "Systemic radial velocity of the source in km/s, positive for recession. Required with --doppler-frame=source, since a cube carries no SOURCE::SYSVEL to fall back on."
+  dtype: float
+doppler-time:
+  info: "Observation epoch for the Doppler correction, as an ISO date or an MJD. Overrides the cube's MJD-OBS or DATE-OBS."
+  dtype: str
+doppler-obs-duration:
+  info: "Length of the observation in hours. Only used to check how far the line-of-sight velocity drifted over the track, and to take the correction at the midpoint rather than the start. Nothing standard records this in a FITS header, so it must be given; without it the drift check is skipped."
+  dtype: float
+doppler-telescope:
+  info: "Observatory name, resolved through astropy's site registry. Overrides the cube's OBSGEO-X/Y/Z or TELESCOP keywords, and is needed when the header carries neither."
+  dtype: str
+doppler-phase-centre:
+  info: "Field centre used to project the observatory velocity, as 'RA,Dec' in degrees or sexagesimal. Overrides the cube's WCS reference coordinate."
+  dtype: str

--- a/src/mowjsub/stimelating/mowjsub_cabs.yaml
+++ b/src/mowjsub/stimelating/mowjsub_cabs.yaml
@@ -10,3 +10,9 @@ cabs:
     command: vis-mowjsub
     inputs:
       _include: (mowjsub.stimelating)vis_mowjsub_param.yaml
+
+  doppler-mowjsub:
+    info: Doppler-correct an already continuum-subtracted Measurement Set (MS) onto a channel grid fixed in a chosen spectral frame
+    command: doppler-mowjsub
+    inputs:
+      _include: (mowjsub.stimelating)doppler_mowjsub_param.yaml

--- a/src/mowjsub/stimelating/vis_mowjsub_param.yaml
+++ b/src/mowjsub/stimelating/vis_mowjsub_param.yaml
@@ -10,9 +10,9 @@ input-column:
       dtype: str
       default: DATA 
 output-column:
-      info: Column name to write the continuum subtracted data to
+      info: "Column name to write the continuum subtracted data to. Required: there is no standard MS column for continuum-subtracted visibilities, so naming one is left to you. Pass DATA if the imager you feed the result to expects that column -- but note that without --output-ms this writes back into the input MS, so it must differ from --input-column."
       dtype: str
-      default: LINE_DATA  
+      required: yes
 fit-model:
       info: "Fit function to model the continuum. The 'scipy-median-filter' model is much faster than 'median-filter', but treats band edges and masked channels differently, so the two do not give identical continuum models. WARNING: A median-filter continuum model may subsume low SNR line emission, use it with great care."
       dtype: str

--- a/src/mowjsub/utils.py
+++ b/src/mowjsub/utils.py
@@ -1,5 +1,6 @@
 import datetime
 import warnings
+from collections import namedtuple
 from typing import Dict
 
 import astropy.io.fits as fitsio
@@ -7,7 +8,8 @@ import dask.array as da
 import numpy as np
 import xarray as xr
 from astropy import units
-from astropy.coordinates import EarthLocation
+from astropy.coordinates import EarthLocation, SkyCoord
+from astropy.time import Time
 from astropy.wcs import WCS
 from casacore.tables import table
 from daskms import Dataset, xds_from_ms, xds_from_table
@@ -18,6 +20,7 @@ from xarrayfits import xds_from_fits
 
 from mowjsub import BIN
 from mowjsub.doppler import (
+    FITS_SPECSYS,
     FRAME_CODES,
     C,
     common_channel_grid,
@@ -25,6 +28,7 @@ from mowjsub.doppler import (
     grid_frequencies,
     parse_channel_grid,
     regrid_rows,
+    resample_cube,
 )
 from mowjsub.image_plane import ContSub
 from mowjsub.masking import Mask, PixSigmaClip
@@ -427,6 +431,39 @@ def copy_ms_subtables(input_ms, output_ms):
         dest.putkeyword("MS_VERSION", keywords.get("MS_VERSION", 2.0))
 
 
+def require_topocentric(spw, spw_id, ms_path):
+    """Refuse a spectral window that has already been moved off the topocentric grid.
+
+    ``doppler_factors`` converts *from* topocentric frequency, so feeding it a
+    window that CASA ``mstransform`` (or an earlier mowjsub run) has already
+    regridded applies the correction twice. Fused into a continuum-subtraction
+    run that cannot happen; reached through ``doppler-mowjsub`` it easily can,
+    since the whole point there is to consume an MS someone else produced.
+
+    Args:
+        spw (Dataset): The MS ``SPECTRAL_WINDOW`` subtable.
+        spw_id (int): Spectral window being processed.
+        ms_path (str|File): MS the window came from, for the error message.
+
+    Raises:
+        RuntimeError: The window's ``MEAS_FREQ_REF`` is not topocentric.
+    """
+    # Not every MS carries the column; absent it, take the grid on trust.
+    if "MEAS_FREQ_REF" not in spw.data_vars:
+        return
+
+    code = int(np.asarray(spw.MEAS_FREQ_REF.values)[spw_id])
+    if code == FRAME_CODES["topo"]:
+        return
+
+    names = {value: key for key, value in FRAME_CODES.items()}
+    found = names.get(code, f"code {code}")
+    raise RuntimeError(
+        f"Spectral window {spw_id} of {ms_path} is already on a {found.upper()} grid, not a topocentric one. "
+        f"Doppler-correcting it would apply the frame conversion twice. Use the MS as it came off the telescope."
+    )
+
+
 def _regrid_block(data, flags, weights, times, utimes, ufactors, freqs_in, freqs_out, interpolation):
     """Regrid one row block, looking each row's Doppler factor up by timestamp."""
     factors = ufactors[np.clip(np.searchsorted(utimes, times), 0, ufactors.size - 1)]
@@ -469,6 +506,8 @@ def doppler_regrid_dataset(
     """
     spw = xds_from_table(f"{ms_path}::SPECTRAL_WINDOW")[0]
     field = xds_from_table(f"{ms_path}::FIELD")[0]
+
+    require_topocentric(spw, spw_id, ms_path)
 
     freqs_in = np.asarray(spw.CHAN_FREQ.values[spw_id], dtype=float)
     phase_centre = np.asarray(field.PHASE_DIR.values[field_id], dtype=float)[0]
@@ -569,6 +608,235 @@ def finalise_regridded_ms(input_ms, output_ms, spw_id, freqs, chanwidth, frame):
         spw.putcell("MEAS_FREQ_REF", spw_id, FRAME_CODES[frame])
 
     log.info(f"Wrote {nchan} channels to {output_ms} on a {frame.upper()} grid, from {freqs[0] / 1e6:.4f} MHz in steps of {chanwidth / 1e3:.4f} kHz")
+
+
+#: Everything needed to move a cube onto a Doppler-corrected grid. Derived once
+#: and applied to both output cubes, so the continuum and line necessarily land
+#: on the same channels.
+CubeDopplerPlan = namedtuple("CubeDopplerPlan", "frame factor freqs_in freqs_out chanwidth axis drift")
+
+
+def cube_spectral_axis(header):
+    """FITS axis number (0-based) of a cube's spectral axis.
+
+    Raises:
+        RuntimeError: The cube has no spectral axis, or has one that mowjsub
+            cannot process.
+    """
+    spec = WCS(header).wcs.spec
+    if spec < 0:
+        raise RuntimeError("This cube has no spectral axis, so there is nothing to Doppler-correct.")
+
+    # A stricter check than the Doppler code alone needs. FitsHeader.retFreq
+    # reads NAXIS3 directly and im-mowjsub writes its continuum back assuming
+    # RA, DEC, FREQ[, STOKES], so a cube with the spectral axis elsewhere fails
+    # confusingly during the fit, long before reaching this point. Say so.
+    if spec != 2:
+        raise RuntimeError(f"mowjsub needs the spectral axis on NAXIS3; this cube has it on NAXIS{spec + 1}. Reorder the axes (e.g. with CASA imtrans) and try again.")
+
+    return spec
+
+
+def _cube_phase_centre(header, override=None):
+    """Field centre of a cube in radians, from the WCS or an explicit override."""
+    if override:
+        parts = [part.strip() for part in str(override).split(",")]
+        if len(parts) != 2:
+            raise ValueError(f"Could not parse phase centre '{override}'. Expected 'RA,Dec', e.g. '13h25m27.6s,-43d01m09s' or '201.365,-43.019'.")
+        try:
+            coord = SkyCoord(float(parts[0]) * units.deg, float(parts[1]) * units.deg)
+        except ValueError:
+            coord = SkyCoord(parts[0], parts[1], unit=(units.hourangle, units.deg))
+        return coord.ra.rad, coord.dec.rad
+
+    ra, dec = WCS(header).celestial.wcs.crval
+
+    return np.radians(float(ra)), np.radians(float(dec))
+
+
+def _cube_time(header, override=None):
+    """Observation epoch of a cube, in seconds since MJD 0 UTC (the MS convention)."""
+    if override:
+        try:
+            epoch = Time(float(override), format="mjd", scale="utc")
+        except ValueError:
+            epoch = Time(str(override), scale="utc")
+        return float(epoch.mjd) * 86400.0
+
+    # Test for a usable value, not merely a present keyword: astropy's WCS
+    # handling leaves an undefined MJD-OBS card behind, and imagers write blank
+    # ones too, so `"MJD-OBS" in header` is not the same question.
+    mjd = header.get("MJD-OBS")
+    if isinstance(mjd, (int, float)) and np.isfinite(mjd):
+        return float(Time(float(mjd), format="mjd", scale="utc").mjd) * 86400.0
+
+    date = header.get("DATE-OBS")
+    if isinstance(date, str) and date.strip():
+        return float(Time(date.strip(), scale="utc").mjd) * 86400.0
+
+    raise RuntimeError("This cube's header records no usable observation time (no MJD-OBS or DATE-OBS), so the Doppler shift cannot be computed. Pass --doppler-time.")
+
+
+def _cube_location(header, override=None):
+    """Observatory position for a cube, from OBSGEO-*, TELESCOP or an override."""
+    if override:
+        try:
+            return EarthLocation.of_site(str(override))
+        except Exception as exc:
+            raise RuntimeError(f"Could not resolve --doppler-telescope='{override}' to a position: {exc}. Give the site in the cube's OBSGEO-X/Y/Z keywords instead.") from None
+
+    if all(f"OBSGEO-{axis}" in header for axis in "XYZ"):
+        return EarthLocation.from_geocentric(
+            float(header["OBSGEO-X"]),
+            float(header["OBSGEO-Y"]),
+            float(header["OBSGEO-Z"]),
+            unit=units.m,
+        )
+
+    if "TELESCOP" in header:
+        name = str(header["TELESCOP"]).strip()
+        try:
+            # Consults astropy's site registry, which may need to be fetched.
+            return EarthLocation.of_site(name)
+        except Exception:
+            raise RuntimeError(
+                f"The cube names TELESCOP='{name}', but that is not in astropy's site registry (or it could not be reached). "
+                f"Pass --doppler-telescope, or add OBSGEO-X/Y/Z to the header."
+            ) from None
+
+    raise RuntimeError("This cube's header records no observatory position (no OBSGEO-X/Y/Z and no TELESCOP), so the Doppler shift cannot be computed. Pass --doppler-telescope.")
+
+
+def plan_cube_doppler(
+    header,
+    frame,
+    chan_grid="auto",
+    obs_time=None,
+    obs_duration=None,
+    telescope=None,
+    phase_centre=None,
+    source_vel=None,
+):
+    """Work out the Doppler correction for a cube, without applying it.
+
+    A cube has already been integrated over time, so unlike the visibility-plane
+    path this produces a *single* factor -- taken at the midpoint of the
+    observation when its length is known. That is only equivalent to the
+    per-timestamp correction when the observatory's line-of-sight velocity
+    drifts by much less than a channel over the track; imaging has already summed
+    over any larger drift, and shifting the axis afterwards cannot undo it. When
+    ``obs_duration`` is given the drift is computed and warned about; when it is
+    not, that check is skipped and the caller is told so.
+
+    Args:
+        header: FITS header of the cube.
+        frame (str): Target frame, one of :data:`mowjsub.doppler.FRAMES`.
+        chan_grid (str): ``'auto'`` or an explicit ``'nchan,chan0,chanwidth'``.
+        obs_time (str, optional): Observation epoch, ISO or MJD, overriding
+            ``MJD-OBS``/``DATE-OBS``.
+        obs_duration (float, optional): Length of the observation in hours. Only
+            used to check the drift.
+        telescope (str, optional): Site name, overriding ``OBSGEO-*``/``TELESCOP``.
+        phase_centre (str, optional): ``'RA,Dec'``, overriding the WCS.
+        source_vel (float, optional): Source systemic velocity in m/s, required
+            for ``frame='source'``.
+
+    Returns:
+        CubeDopplerPlan
+    """
+    axis = cube_spectral_axis(header)
+
+    centre = _cube_phase_centre(header, phase_centre)
+    location = _cube_location(header, telescope)
+    epoch = _cube_time(header, obs_time)
+
+    # retFreq reads the grid through astropy's high-level WCS, which insists on a
+    # usable observation time even to convert pixels to frequencies. Hand it the
+    # epoch resolved above, so --doppler-time rescues a header that lacks one
+    # instead of failing deep inside astropy.
+    spectral_header = fitsio.Header(header)
+    spectral_header["MJD-OBS"] = epoch / 86400.0
+
+    # retFreq works in MHz; everything in doppler.py that is not scale-free
+    # (parse_channel_grid) works in Hz, so normalise here.
+    freqs_in = np.asarray(FitsHeader(spectral_header).retFreq(), dtype=float) * 1e6
+
+    if frame == "source" and source_vel is None:
+        raise RuntimeError("--doppler-frame=source needs a systemic velocity, and a cube carries none. Pass --doppler-source-vel.")
+
+    span = None if obs_duration in (None, 0) else float(obs_duration) * 3600.0
+    midpoint = epoch if span is None else epoch + 0.5 * span
+    factor = float(doppler_factors([midpoint], centre, location, frame, source_vel=source_vel)[0])
+
+    if str(chan_grid).lower() == "auto":
+        nchan, chan0, chanwidth = common_channel_grid(freqs_in, [factor])
+        log.info(f"Derived a {frame.upper()} channel grid: {nchan} channels from {chan0 / 1e6:.4f} MHz in steps of {chanwidth / 1e3:.4f} kHz")
+    else:
+        nchan, chan0, chanwidth = parse_channel_grid(chan_grid)
+        log.info(f"Using the requested {frame.upper()} channel grid: {nchan} channels from {chan0 / 1e6:.4f} MHz in steps of {chanwidth / 1e3:.4f} kHz")
+
+    freqs_out = grid_frequencies(nchan, chan0, chanwidth)
+
+    drift = None
+    if span is not None:
+        edges = doppler_factors([epoch, epoch + span], centre, location, frame, source_vel=source_vel)
+        drift = float(abs(edges.max() - edges.min()) * C)
+
+        # The comparison that decides whether a cube-plane correction is
+        # defensible at all. Both quantities scale with frequency, so the ratio
+        # does not depend on where in the band it is evaluated.
+        chan_velocity = abs(chanwidth) / (0.5 * (freqs_out[0] + freqs_out[-1])) * C
+        log.info(f"Doppler correction to {frame.upper()}: line-of-sight velocity drifts by {drift:.3f} m/s over {obs_duration:g} h, against a {chan_velocity:.3f} m/s channel")
+        if drift > 0.1 * chan_velocity:
+            log.warning(
+                f"That drift is {drift / chan_velocity:.2f} of a channel. A cube has already been integrated over time, so this correction applies one factor to all of it "
+                f"and cannot undo the smearing the drift has already caused. Correct in the visibility plane instead (doppler-mowjsub, or vis-mowjsub --doppler-frame)."
+            )
+    else:
+        log.info(f"Doppler correction to {frame.upper()}: factor {factor:.9f} at the observation epoch. Pass --doppler-obs-duration to check the drift over the track.")
+
+    return CubeDopplerPlan(frame=frame, factor=factor, freqs_in=freqs_in, freqs_out=freqs_out, chanwidth=chanwidth, axis=axis, drift=drift)
+
+
+def apply_cube_doppler(data, header, plan, interpolation="nearest"):
+    """Resample a cube onto the grid in ``plan`` and rewrite its spectral WCS.
+
+    Args:
+        data (np.ndarray|dask.array): Cube in FITS axis order.
+        header: FITS header to base the output header on.
+        plan (CubeDopplerPlan): From :func:`plan_cube_doppler`.
+        interpolation (str): ``'nearest'`` or ``'linear'``.
+
+    Returns:
+        tuple: ``(data, header)`` on the corrected grid.
+    """
+    # plan.axis is a FITS axis index; the array is in C order, i.e. reversed.
+    numpy_axis = np.ndim(data) - 1 - plan.axis
+
+    resampled = resample_cube(data, plan.factor, plan.freqs_in, plan.freqs_out, numpy_axis, interpolation)
+
+    out = fitsio.Header(header)
+    keyword = plan.axis + 1
+    out[f"NAXIS{keyword}"] = plan.freqs_out.size
+    out[f"CRPIX{keyword}"] = 1.0
+    out[f"CRVAL{keyword}"] = float(plan.freqs_out[0])
+    out[f"CDELT{keyword}"] = float(plan.chanwidth)
+    out[f"CUNIT{keyword}"] = "Hz"
+    out["SPECSYS"] = FITS_SPECSYS[plan.frame]
+
+    # A CD matrix takes precedence over CDELT, and a PC matrix multiplies it, so
+    # a stale entry on the spectral axis would silently undo the line above.
+    if f"CD{keyword}_{keyword}" in out:
+        out[f"CD{keyword}_{keyword}"] = float(plan.chanwidth)
+    if f"PC{keyword}_{keyword}" in out:
+        out[f"PC{keyword}_{keyword}"] = 1.0
+
+    # Velocity-referenced duplicates of the spectral axis. They describe the old
+    # grid, and a reader that trusts them over CRVAL3 would be silently wrong.
+    for stale in ("ALTRVAL", "ALTRPIX", "VELREF"):
+        out.pop(stale, None)
+
+    return resampled, out
 
 
 def ms_to_xarray_dataset(

--- a/tests/test_doppler.py
+++ b/tests/test_doppler.py
@@ -312,7 +312,7 @@ class TestEndToEnd(unittest.TestCase):
 
         result = CliRunner().invoke(
             runit,
-            [str(self.ms), "--fit-model", "polynomial", "--order", "2", "--output-ms", str(output), *extra],
+            [str(self.ms), "--fit-model", "polynomial", "--order", "2", "--output-column", "LINE_DATA", "--output-ms", str(output), *extra],
             catch_exceptions=True,
         )
         return result
@@ -391,12 +391,243 @@ class TestEndToEnd(unittest.TestCase):
 
         result = CliRunner().invoke(
             runit,
-            [str(self.ms), "--fit-model", "polynomial", "--order", "2", "--doppler-frame", "bary"],
+            [str(self.ms), "--fit-model", "polynomial", "--order", "2", "--output-column", "LINE_DATA", "--doppler-frame", "bary"],
             catch_exceptions=True,
         )
 
         assert result.exit_code != 0
         assert "output-ms" in str(result.exception)
+
+    def test_output_column_has_no_default(self):
+        """Omitting --output-column must be an error, not a silent LINE_DATA."""
+        from click.testing import CliRunner
+
+        from mowjsub.parser.vis_mowjsub import runit
+
+        result = CliRunner().invoke(
+            runit,
+            [str(self.ms), "--fit-model", "polynomial", "--order", "2", "--output-ms", str(self.tmpdir / "nope.ms")],
+            catch_exceptions=True,
+        )
+
+        assert result.exit_code != 0
+        assert "output-column" in result.output
+
+    def test_writing_the_input_column_in_place_is_refused(self):
+        """In place, --output-column == --input-column destroys the input."""
+        from click.testing import CliRunner
+
+        from mowjsub.parser.vis_mowjsub import runit
+
+        result = CliRunner().invoke(
+            runit,
+            [str(self.ms), "--fit-model", "polynomial", "--order", "2", "--input-column", "DATA", "--output-column", "DATA"],
+            catch_exceptions=True,
+        )
+
+        assert result.exit_code != 0
+        assert "overwriting it" in str(result.exception)
+
+
+class TestStandaloneDoppler(unittest.TestCase):
+    """doppler-mowjsub over an MS whose continuum has already gone."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tmpdir = Path(tempfile.mkdtemp(prefix="mowjsub-standalone-"))
+        cls.ms = cls.tmpdir / "test.ms"
+        try:
+            _make_ms(cls.ms)
+        except Exception as exc:  # pragma: no cover
+            shutil.rmtree(cls.tmpdir, ignore_errors=True)
+            raise unittest.SkipTest(f"could not build a test MS: {exc}") from exc
+
+        # The line MS the standalone command is meant to consume: continuum
+        # subtracted on the native topocentric grid, no Doppler correction yet.
+        cls.line_ms = cls.tmpdir / "line.ms"
+        result = cls._contsub(cls.line_ms)
+        if result.exit_code != 0:  # pragma: no cover
+            shutil.rmtree(cls.tmpdir, ignore_errors=True)
+            raise unittest.SkipTest(f"could not build a line MS: {result.output}")
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.tmpdir, ignore_errors=True)
+
+    @classmethod
+    def _contsub(cls, output, *extra):
+        from click.testing import CliRunner
+
+        from mowjsub.parser.vis_mowjsub import runit
+
+        return CliRunner().invoke(
+            runit,
+            [str(cls.ms), "--fit-model", "polynomial", "--order", "2", "--output-column", "LINE_DATA", "--output-ms", str(output), *extra],
+            catch_exceptions=True,
+        )
+
+    def _run(self, ms, output, *extra):
+        from click.testing import CliRunner
+
+        from mowjsub.parser.doppler_mowjsub import runit
+
+        return CliRunner().invoke(
+            runit,
+            [str(ms), "--input-column", "LINE_DATA", "--output-column", "LINE_DATA", "--output-ms", str(output), *extra],
+            catch_exceptions=True,
+        )
+
+    def test_writes_a_regridded_ms(self):
+        from casacore.tables import table
+
+        output = self.tmpdir / "bary.ms"
+        result = self._run(self.line_ms, output, "--doppler-frame", "bary")
+        assert result.exit_code == 0, result.output
+
+        with table(str(output), ack=False) as main:
+            keywords = {k for k, v in main.getkeywords().items() if isinstance(v, str) and v.startswith("Table:")}
+            assert {"ANTENNA", "FIELD", "SPECTRAL_WINDOW", "POLARIZATION", "DATA_DESCRIPTION"} <= keywords
+            assert "FIELD_ID" in main.colnames() and "DATA_DESC_ID" in main.colnames()
+            nchan_out = main.getcol("LINE_DATA").shape[1]
+
+        with table(f"{output}/SPECTRAL_WINDOW", ack=False) as spw:
+            assert spw.getcell("NUM_CHAN", 0) == nchan_out
+            assert spw.getcell("MEAS_FREQ_REF", 0) == FRAME_CODES["bary"]
+            assert nchan_out < 32
+
+    def test_matches_the_fused_single_pass(self):
+        """Subtract-then-correct must equal vis-mowjsub's fused --doppler-frame."""
+        from casacore.tables import table
+
+        fused = self.tmpdir / "fused.ms"
+        assert self._contsub(fused, "--doppler-frame", "bary").exit_code == 0
+
+        split = self.tmpdir / "split.ms"
+        assert self._run(self.line_ms, split, "--doppler-frame", "bary").exit_code == 0
+
+        with table(str(fused), ack=False) as a, table(str(split), ack=False) as b:
+            # Same grid, and the same visibilities on it. Both orders fit on the
+            # topocentric grid and regrid only the residual, so this is exact --
+            # the intermediate MS round-trip preserves complex64.
+            assert np.array_equal(a.getcol("LINE_DATA"), b.getcol("LINE_DATA"))
+            assert np.array_equal(a.getcol("FLAG"), b.getcol("FLAG"))
+
+    def test_explicit_grid_is_honoured(self):
+        from casacore.tables import table
+
+        output = self.tmpdir / "lsrk.ms"
+        result = self._run(self.line_ms, output, "--doppler-frame", "lsrk", "--doppler-chan-grid", "20,1405MHz,1MHz")
+        assert result.exit_code == 0, result.output
+
+        with table(f"{output}/SPECTRAL_WINDOW", ack=False) as spw:
+            assert spw.getcell("NUM_CHAN", 0) == 20
+            assert spw.getcell("MEAS_FREQ_REF", 0) == FRAME_CODES["lsrk"]
+            assert np.isclose(spw.getcell("CHAN_FREQ", 0)[0], 1405e6)
+
+    def test_input_ms_is_left_alone(self):
+        from casacore.tables import table
+
+        self._run(self.line_ms, self.tmpdir / "untouched.ms", "--doppler-frame", "bary")
+
+        with table(str(self.line_ms), ack=False) as main:
+            assert main.getcol("LINE_DATA").shape[1] == 32
+
+    def test_the_intermediate_ms_has_no_data_column(self):
+        """Pins why --input-column has no default: DATA is simply not there."""
+        from casacore.tables import table
+
+        with table(str(self.line_ms), ack=False) as main:
+            assert "LINE_DATA" in main.colnames()
+            assert "DATA" not in main.colnames()
+
+    def test_a_missing_column_is_reported(self):
+        result = self._run_columns(self.line_ms, self.tmpdir / "missing.ms", "NOPE_DATA")
+
+        assert result.exit_code != 0
+        assert "NOPE_DATA" in str(result.exception)
+        # The error must name what is actually available.
+        assert "LINE_DATA" in str(result.exception)
+
+    def _run_columns(self, ms, output, input_column):
+        from click.testing import CliRunner
+
+        from mowjsub.parser.doppler_mowjsub import runit
+
+        return CliRunner().invoke(
+            runit,
+            [str(ms), "--input-column", input_column, "--output-column", "LINE_DATA", "--output-ms", str(output), "--doppler-frame", "bary"],
+            catch_exceptions=True,
+        )
+
+    def test_a_non_topocentric_input_is_refused(self):
+        """Correcting an already-regridded MS would apply the shift twice."""
+        import shutil as _shutil
+
+        from casacore.tables import table
+
+        already = self.tmpdir / "already-bary.ms"
+        _shutil.rmtree(already, ignore_errors=True)
+        _shutil.copytree(self.line_ms, already)
+        with table(f"{already}/SPECTRAL_WINDOW", readonly=False, ack=False, lockoptions="auto") as spw:
+            spw.putcell("MEAS_FREQ_REF", 0, FRAME_CODES["bary"])
+
+        result = self._run(already, self.tmpdir / "twice.ms", "--doppler-frame", "lsrk")
+
+        assert result.exit_code != 0
+        assert "BARY" in str(result.exception)
+        assert "twice" in str(result.exception)
+
+    def test_the_fused_path_refuses_a_non_topocentric_input_too(self):
+        """The guard lives in the shared helper, so vis-mowjsub gets it as well."""
+        import shutil as _shutil
+
+        from casacore.tables import table
+
+        already = self.tmpdir / "already-lsrk.ms"
+        _shutil.rmtree(already, ignore_errors=True)
+        _shutil.copytree(self.ms, already)
+        with table(f"{already}/SPECTRAL_WINDOW", readonly=False, ack=False, lockoptions="auto") as spw:
+            spw.putcell("MEAS_FREQ_REF", 0, FRAME_CODES["lsrk"])
+
+        from click.testing import CliRunner
+
+        from mowjsub.parser.vis_mowjsub import runit
+
+        result = CliRunner().invoke(
+            runit,
+            [
+                str(already),
+                "--fit-model",
+                "polynomial",
+                "--order",
+                "2",
+                "--output-column",
+                "LINE_DATA",
+                "--output-ms",
+                str(self.tmpdir / "nope2.ms"),
+                "--doppler-frame",
+                "bary",
+            ],
+            catch_exceptions=True,
+        )
+
+        assert result.exit_code != 0
+        assert "LSRK" in str(result.exception)
+
+    def test_required_options_are_enforced(self):
+        from click.testing import CliRunner
+
+        from mowjsub.parser.doppler_mowjsub import runit
+
+        for missing, args in (
+            ("doppler-frame", ["--input-column", "LINE_DATA", "--output-column", "L", "--output-ms", "x.ms"]),
+            ("output-ms", ["--input-column", "LINE_DATA", "--output-column", "L", "--doppler-frame", "bary"]),
+            ("input-column", ["--output-column", "L", "--output-ms", "x.ms", "--doppler-frame", "bary"]),
+            ("output-column", ["--input-column", "LINE_DATA", "--output-ms", "x.ms", "--doppler-frame", "bary"]),
+        ):
+            result = CliRunner().invoke(runit, [str(self.line_ms), *args], catch_exceptions=True)
+            assert result.exit_code != 0, missing
+            assert missing in result.output, missing
 
 
 def _make_ms(path, nant=4, ntime=4, nchan=32, ncorr=2, f0=1.4e9, df=1e6):

--- a/tests/test_doppler_image.py
+++ b/tests/test_doppler_image.py
@@ -345,6 +345,26 @@ class TestEndToEnd(unittest.TestCase):
 
         assert line.exists()
 
+    def test_an_unsupported_axis_order_is_refused_clearly(self):
+        """Whether or not Doppler is asked for: the axis order is the problem."""
+        swapped = self.tmpdir / "swapped.fits"
+        header = _header(spectral_axis=4)
+        # C order is reversed: FREQ, STOKES, DEC, RA.
+        fitsio.PrimaryHDU(np.ones((32, 1, 4, 4), dtype=np.float32), header=header).writeto(swapped)
+
+        for extra in ([], ["--doppler-frame", "bary"]):
+            result = CliRunner().invoke(
+                runit,
+                [str(swapped), "--output-prefix", str(self.tmpdir / "sw"), "--fit-model", "polynomial", "--order", "2", *extra],
+                catch_exceptions=True,
+            )
+
+            assert result.exit_code != 0
+            # Not the bare "conflicting sizes for dimension 'spectral'" that
+            # xds_from_fits raises if this is left to fail on its own.
+            assert "NAXIS3" in str(result.exception), extra
+            assert "NAXIS4" in str(result.exception), extra
+
     def test_source_frame_without_a_velocity_is_refused(self):
         result, _, _ = self._run("--doppler-frame", "source")
 

--- a/tests/test_doppler_image.py
+++ b/tests/test_doppler_image.py
@@ -1,0 +1,356 @@
+"""Image-plane Doppler correction: `im-mowjsub --doppler-frame`.
+
+These build synthetic FITS cubes rather than Measurement Sets, so nothing here
+needs casacore.
+"""
+
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+import astropy.io.fits as fitsio
+import numpy as np
+from click.testing import CliRunner
+
+from mowjsub.doppler import FITS_SPECSYS, resample_cube
+from mowjsub.parser.im_mowjsub import runit
+from mowjsub.utils import apply_cube_doppler, cube_spectral_axis, plan_cube_doppler
+
+# MeerKAT, as ITRF metres, matching tests/test_doppler.py.
+MEERKAT = (5109360.133, 2006852.586, -3238948.127)
+
+
+def _header(nchan=32, f0=1.4e9, df=1e6, npix=4, stokes=False, spectral_axis=3):
+    """A minimal but WCS-complete spectral cube header.
+
+    NAXIS* are set explicitly because ``FitsHeader.retFreq`` reads ``NAXIS3``
+    straight off the header, without a data array to infer it from.
+
+    ``spectral_axis=4`` puts STOKES on NAXIS3 and FREQ on NAXIS4, the layout
+    mowjsub does not support; it exists here only to pin the refusal.
+    """
+    header = fitsio.Header()
+    header["CTYPE1"] = "RA---SIN"
+    header["CRVAL1"] = 201.36506
+    header["CDELT1"] = -1.0 / 3600
+    header["CRPIX1"] = npix / 2
+    header["CUNIT1"] = "deg"
+    header["CTYPE2"] = "DEC--SIN"
+    header["CRVAL2"] = -43.01911
+    header["CDELT2"] = 1.0 / 3600
+    header["CRPIX2"] = npix / 2
+    header["CUNIT2"] = "deg"
+
+    spectral = ({"CTYPE": "FREQ", "CRVAL": f0, "CDELT": df, "CRPIX": 1.0, "CUNIT": "Hz"}, nchan)
+    stokes_axis = ({"CTYPE": "STOKES", "CRVAL": 1.0, "CDELT": 1.0, "CRPIX": 1.0, "CUNIT": ""}, 1)
+
+    if spectral_axis == 4:
+        trailing = [stokes_axis, spectral]
+    else:
+        trailing = [spectral, stokes_axis] if stokes else [spectral]
+
+    for index, (axis, length) in enumerate(trailing, start=3):
+        for key, value in axis.items():
+            header[f"{key}{index}"] = value
+        header[f"NAXIS{index}"] = length
+
+    header["NAXIS"] = 2 + len(trailing)
+    header["NAXIS1"] = npix
+    header["NAXIS2"] = npix
+
+    header["DATE-OBS"] = "2020-01-01T00:00:00"
+    header["OBSGEO-X"], header["OBSGEO-Y"], header["OBSGEO-Z"] = MEERKAT
+    header["SPECSYS"] = "TOPOCENT"
+    header["RESTFRQ"] = 1.42040575e9
+    header["BUNIT"] = "Jy/beam"
+
+    return header
+
+
+def _cube(path, nchan=32, npix=4, line_channel=None, stokes=False, **kwargs):
+    """Write a flat-spectrum cube, optionally with a one-channel spike."""
+    header = _header(nchan=nchan, npix=npix, stokes=stokes, **kwargs)
+
+    # C order is the reverse of FITS axis order: RA, DEC, FREQ[, STOKES].
+    shape = ([1] if stokes else []) + [nchan, npix, npix]
+    data = np.ones(shape, dtype=np.float32)
+
+    if line_channel is not None:
+        index = [slice(None)] * len(shape)
+        index[1 if stokes else 0] = line_channel
+        data[tuple(index)] = 10.0
+
+    fitsio.PrimaryHDU(data, header=header).writeto(path, overwrite=True)
+
+    return header
+
+
+class TestSpectralAxis(unittest.TestCase):
+    def test_naxis3_is_accepted(self):
+        assert cube_spectral_axis(_header()) == 2
+
+    def test_a_spectral_axis_elsewhere_is_refused(self):
+        """Stated limitation: retFreq and the continuum writeback assume NAXIS3."""
+        with self.assertRaises(RuntimeError) as raised:
+            cube_spectral_axis(_header(spectral_axis=4))
+
+        assert "NAXIS3" in str(raised.exception)
+        assert "NAXIS4" in str(raised.exception)
+
+    def test_a_cube_with_no_spectral_axis_is_refused(self):
+        header = _header()
+        for key in ("CTYPE3", "CRVAL3", "CDELT3", "CRPIX3", "CUNIT3"):
+            header.pop(key, None)
+
+        with self.assertRaises(RuntimeError) as raised:
+            cube_spectral_axis(header)
+
+        assert "no spectral axis" in str(raised.exception)
+
+
+class TestPlan(unittest.TestCase):
+    def test_topo_is_the_identity_factor(self):
+        plan = plan_cube_doppler(_header(), "topo")
+
+        assert plan.factor == 1.0
+        # 'auto' still drops a guard channel at each end.
+        assert plan.freqs_out.size == 30
+
+    def test_bary_factor_is_physical(self):
+        plan = plan_cube_doppler(_header(), "bary")
+
+        assert abs(1.0 - plan.factor) * 299792458.0 < 32e3
+
+    def test_explicit_grid_is_used_verbatim(self):
+        plan = plan_cube_doppler(_header(), "bary", chan_grid="10,1401MHz,2MHz")
+
+        assert plan.freqs_out.size == 10
+        assert np.isclose(plan.freqs_out[0], 1401e6)
+        assert np.isclose(plan.chanwidth, 2e6)
+
+    def test_source_frame_needs_a_velocity(self):
+        with self.assertRaises(RuntimeError) as raised:
+            plan_cube_doppler(_header(), "source")
+
+        assert "doppler-source-vel" in str(raised.exception)
+
+    def test_duration_gives_a_drift(self):
+        plan = plan_cube_doppler(_header(), "bary", obs_duration=8.0)
+
+        # Eight hours of Earth rotation, so hundreds of m/s but under a km/s.
+        assert plan.drift is not None
+        assert 50.0 < plan.drift < 1000.0
+
+    def test_no_duration_means_no_drift_check(self):
+        assert plan_cube_doppler(_header(), "bary").drift is None
+
+    def test_missing_location_is_reported(self):
+        header = _header()
+        for key in ("OBSGEO-X", "OBSGEO-Y", "OBSGEO-Z"):
+            header.pop(key, None)
+
+        with self.assertRaises(RuntimeError) as raised:
+            plan_cube_doppler(header, "bary")
+
+        assert "doppler-telescope" in str(raised.exception)
+
+    def test_missing_time_is_reported(self):
+        header = _header()
+        header.pop("DATE-OBS", None)
+
+        with self.assertRaises(RuntimeError) as raised:
+            plan_cube_doppler(header, "bary")
+
+        assert "doppler-time" in str(raised.exception)
+
+    def test_doppler_time_rescues_a_header_with_no_epoch(self):
+        """retFreq needs an obstime of its own, so the override must reach it."""
+        header = _header()
+        header.pop("DATE-OBS", None)
+
+        plan = plan_cube_doppler(header, "bary", obs_time="2020-01-01T00:00:00")
+
+        assert np.isclose(plan.factor, plan_cube_doppler(_header(), "bary").factor)
+
+    def test_overrides_are_honoured(self):
+        """With no header metadata at all, the overrides must carry the plan."""
+        header = _header()
+        for key in ("DATE-OBS", "OBSGEO-X", "OBSGEO-Y", "OBSGEO-Z"):
+            header.pop(key, None)
+
+        plan = plan_cube_doppler(
+            header,
+            "bary",
+            obs_time="2020-01-01T00:00:00",
+            telescope="MeerKAT",
+            phase_centre="201.36506,-43.01911",
+        )
+
+        assert np.isclose(plan.factor, plan_cube_doppler(_header(), "bary").factor, rtol=0, atol=1e-9)
+
+
+class TestApply(unittest.TestCase):
+    def test_a_whole_channel_shift_moves_the_line(self):
+        """An output grid offset by one channel moves the spike by one channel."""
+        header = _header(nchan=32, f0=1.4e9, df=1e6)
+        data = np.ones((32, 4, 4), dtype=np.float32)
+        data[10] = 10.0
+
+        plan = plan_cube_doppler(header, "topo", chan_grid="30,1401MHz,1MHz")
+        shifted, out = apply_cube_doppler(data, header, plan)
+
+        # Output channel 0 is input channel 1, so the spike lands at 10 - 1.
+        assert np.argmax(shifted[:, 0, 0]) == 9
+        assert out["CRVAL3"] == 1401e6
+        assert out["NAXIS3"] == 30
+
+    def test_header_is_rewritten(self):
+        header = _header()
+        data = np.ones((32, 4, 4), dtype=np.float32)
+
+        plan = plan_cube_doppler(header, "lsrk")
+        _, out = apply_cube_doppler(data, header, plan)
+
+        assert out["SPECSYS"] == FITS_SPECSYS["lsrk"]
+        assert out["CUNIT3"] == "Hz"
+        assert out["CRPIX3"] == 1.0
+        assert np.isclose(out["CRVAL3"], plan.freqs_out[0])
+        assert np.isclose(out["CDELT3"], plan.chanwidth)
+        # Untouched keywords survive.
+        assert out["BUNIT"] == "Jy/beam"
+        assert out["RESTFRQ"] == 1.42040575e9
+
+    def test_stale_velocity_keywords_are_dropped(self):
+        header = _header()
+        header["ALTRVAL"] = 1.0e5
+        header["ALTRPIX"] = 3.0
+        header["VELREF"] = 257
+
+        plan = plan_cube_doppler(header, "bary")
+        _, out = apply_cube_doppler(np.ones((32, 4, 4), dtype=np.float32), header, plan)
+
+        for stale in ("ALTRVAL", "ALTRPIX", "VELREF"):
+            assert stale not in out, stale
+
+    def test_a_cd_matrix_is_kept_consistent(self):
+        header = _header()
+        header["CD3_3"] = 1e6
+
+        plan = plan_cube_doppler(header, "bary")
+        _, out = apply_cube_doppler(np.ones((32, 4, 4), dtype=np.float32), header, plan)
+
+        assert np.isclose(out["CD3_3"], plan.chanwidth)
+
+    def test_dtype_is_preserved(self):
+        plan = plan_cube_doppler(_header(), "bary")
+        resampled, _ = apply_cube_doppler(np.ones((32, 4, 4), dtype=np.float32), _header(), plan)
+
+        assert resampled.dtype == np.float32
+
+    def test_channels_off_the_band_become_nan(self):
+        freqs_in = 1.4e9 + 1e6 * np.arange(16)
+        data = np.ones((16, 2, 2), dtype=np.float32)
+        # Ask for four channels beyond the top of the band.
+        freqs_out = freqs_in + 4e6
+
+        resampled = resample_cube(data, 1.0, freqs_in, freqs_out, axis=0)
+
+        assert np.isnan(resampled[-4:]).all()
+        assert not np.isnan(resampled[:-4]).any()
+
+    def test_stokes_cube_resamples_on_the_right_axis(self):
+        """The spectral axis is NAXIS3, i.e. numpy axis 1 in a 4-D cube."""
+        header = _header(stokes=True)
+        data = np.ones((1, 32, 4, 4), dtype=np.float32)
+        data[0, 10] = 10.0
+
+        plan = plan_cube_doppler(header, "topo", chan_grid="30,1401MHz,1MHz")
+        shifted, _ = apply_cube_doppler(data, header, plan)
+
+        assert shifted.shape == (1, 30, 4, 4)
+        assert np.argmax(shifted[0, :, 0, 0]) == 9
+
+
+class TestEndToEnd(unittest.TestCase):
+    """Run im-mowjsub over a synthetic cube and inspect what it writes."""
+
+    def setUp(self):
+        self.tmpdir = Path(tempfile.mkdtemp(prefix="mowjsub-imdoppler-"))
+        self.cube = self.tmpdir / "cube.fits"
+        _cube(self.cube, nchan=32)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def _run(self, *extra):
+        prefix = str(self.tmpdir / "out")
+        return (
+            CliRunner().invoke(
+                runit,
+                [str(self.cube), "--output-prefix", prefix, "--fit-model", "polynomial", "--order", "2", *extra],
+                catch_exceptions=True,
+            ),
+            Path(f"{prefix}-cont.fits"),
+            Path(f"{prefix}-line.fits"),
+        )
+
+    def test_without_a_frame_the_grid_is_untouched(self):
+        result, cont, line = self._run()
+        assert result.exit_code == 0, result.output
+
+        for path in (cont, line):
+            with fitsio.open(path) as hdul:
+                assert hdul[0].header["NAXIS3"] == 32
+                assert hdul[0].header["SPECSYS"] == "TOPOCENT"
+
+    def test_both_cubes_land_on_the_corrected_grid(self):
+        result, cont, line = self._run("--doppler-frame", "bary")
+        assert result.exit_code == 0, result.output
+
+        headers = []
+        for path in (cont, line):
+            with fitsio.open(path) as hdul:
+                headers.append(hdul[0].header)
+                assert hdul[0].header["SPECSYS"] == FITS_SPECSYS["bary"]
+                # Guard channels mean the grid is narrower than the input band.
+                # Not a fixed count: 'auto' drops one channel at each end, and
+                # which side of the floor() in common_channel_grid a shifted
+                # grid lands on costs at most one more.
+                assert 28 <= hdul[0].header["NAXIS3"] <= 30
+
+        # The pair must remain recombinable, i.e. be on one identical grid.
+        for key in ("NAXIS3", "CRVAL3", "CDELT3", "CRPIX3", "SPECSYS"):
+            assert headers[0][key] == headers[1][key], key
+
+    def test_the_scratch_continuum_is_cleaned_up(self):
+        result, _, _ = self._run("--doppler-frame", "bary")
+        assert result.exit_code == 0, result.output
+
+        assert not (self.tmpdir / "out-cont-topo.fits").exists()
+        assert sorted(p.name for p in self.tmpdir.glob("*.fits")) == ["cube.fits", "out-cont.fits", "out-line.fits"]
+
+    def test_explicit_grid_is_honoured(self):
+        result, _, line = self._run("--doppler-frame", "lsrk", "--doppler-chan-grid", "20,1405MHz,1MHz")
+        assert result.exit_code == 0, result.output
+
+        with fitsio.open(line) as hdul:
+            assert hdul[0].header["NAXIS3"] == 20
+            assert np.isclose(hdul[0].header["CRVAL3"], 1405e6)
+            assert hdul[0].header["SPECSYS"] == FITS_SPECSYS["lsrk"]
+
+    def test_a_large_drift_warns_but_still_runs(self):
+        result, _, line = self._run("--doppler-frame", "bary", "--doppler-obs-duration", "8")
+        assert result.exit_code == 0, result.output
+
+        assert line.exists()
+
+    def test_source_frame_without_a_velocity_is_refused(self):
+        result, _, _ = self._run("--doppler-frame", "source")
+
+        assert result.exit_code != 0
+        assert "doppler-source-vel" in str(result.exception)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #42.

The issue offered two shapes and asked for a deliberate choice. Both are implemented, because they are not two spellings of one feature — the visibility-plane path preserves information the cube-plane path cannot recover.

## `doppler-mowjsub` (Option 1)

The same `--doppler-*` parameters `vis-mowjsub` takes, over an MS whose continuum has already gone:

```bash
doppler-mowjsub line.ms \
  --input-column LINE_DATA --output-column DATA \
  --doppler-frame bary --output-ms out.ms
```

Reuses `doppler_regrid_dataset`/`finalise_regridded_ms` unchanged and does no fitting. This is what removes the need to refuse `mstransform` + `vis_contsub` at build time in caracal2's `line` worker.

`vis-mowjsub --doppler-frame` is unchanged and stays the convenient default. The split and fused paths are pinned against each other in `TestStandaloneDoppler::test_matches_the_fused_single_pass`, which asserts exact equality — the intermediate MS round-trip preserves `complex64`.

## `im-mowjsub --doppler-frame` (Option 2)

One interpolation, at the very end, applied to both output cubes so the pair stays recombinable.

The caveat is physical and the docs lead with it rather than with the interpolation count. The Doppler factor is time-dependent; a cube has already been integrated over time, so only a single factor can be applied and the intra-track smearing is unrecoverable. The deciding test is a ratio:

> safe when the drift over the observation is much smaller than one channel

`--doppler-obs-duration` makes that empirical: mowjsub computes the drift, logs it against the channel width and warns past a tenth of a channel. Both quantities scale with frequency, so the ratio needs no reference frequency.

Worth noting the asymmetry that makes this the deciding factor rather than the interpolation count: the continuum model lives on `--vel-width` scales (250 km/s ≈ 1184 kHz at 1420 MHz), so smearing *it* is negligible, while the line is judged at channel resolution. The image-plane path is unambiguously right for stacking several observations onto one grid, which is a pure shift per cube.

Cube metadata is resolved from the header (`MJD-OBS`/`DATE-OBS`, `OBSGEO-*`/`TELESCOP`, celestial WCS) with `--doppler-time`, `--doppler-telescope` and `--doppler-phase-centre` as overrides.

## Two fixes that fell out

**`vis-mowjsub --output-column` loses its `LINE_DATA` default and becomes required.** `LINE_DATA` is not an MS-standard name. There is no standard name for continuum-subtracted visibilities, so *no* default is correct: an MS from `--output-ms` has no `DATA` column at all (`output_ms_dataset` drops `CHANNEL_COLUMNS` and re-adds only what the caller passes), while an in-place run leaves `DATA` holding the raw visibilities. Breaking CLI change, taken during the 2.0 release candidates rather than after.

Dropping the default exposed a hazard it was hiding: without `--output-ms` the residual is written back into the input MS, so `--output-column DATA` there would overwrite the visibilities the fit was made from. Now refused.

**`doppler_regrid_dataset` requires a topocentric input grid.** Checked against `SPECTRAL_WINDOW::MEAS_FREQ_REF`. This closes a live hole in `vis-mowjsub --doppler-frame`, which would previously have applied the frame conversion on top of one `mstransform` had already applied.

## Known limitation

The image-plane path requires the spectral axis on `NAXIS3`, and refuses anything else with a clear message. A cube with `CTYPE3=STOKES`, `CTYPE4=FREQ` already fails upstream of any Doppler code — `FitsHeader.retFreq` hardcodes `NAXIS3` and the continuum writeback assumes the same order — so this converts a confusing failure into a stated one rather than fixing it. Worth a follow-up issue.

## Verification

- 74 passed, 1 skipped (from 37 passed, 1 skipped). The skip is `TestCasacoreAgreement`, which needs casacore measures data.
- `ruff check` + `ruff format --check` clean.
- Sphinx docs build clean; `reference.rst` now documents all three commands (`vis-mowjsub` was missing before).
- `uv.lock` unchanged — a new entry point is not a dependency change.

## For reviewers

`caracal2`'s `line` worker may invoke `vis-mowjsub` without `--output-column`, or read `LINE_DATA` by name. If so that needs a coordinated change on their side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)