### PR TITLE
Read the cube's channel grid from the WCS, not from NAXIS3

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,7 +71,11 @@ The first two apply **one factor per timestamp**. The image-plane path cannot: a
 
 `doppler_regrid_dataset` requires a topocentric input grid (`require_topocentric`, checked against `SPECTRAL_WINDOW::MEAS_FREQ_REF`), so an MS that `mstransform` already regridded is refused rather than corrected twice.
 
-Two traps in the image-plane path: `FitsHeader.retFreq()` returns **MHz** while `parse_channel_grid` returns **Hz**, so cube frequencies are converted before touching `doppler.py`; and `retFreq` goes through astropy's high-level WCS, which needs a usable obstime even to convert pixels to frequencies, so `plan_cube_doppler` resolves the epoch first and stamps it into the header copy it passes on. `FITS_SPECSYS` (FITS keyword names) and `FRAME_CODES` (MS integer codes) describe the same frames for different formats and must not be substituted for one another.
+The cube's channel grid comes from `utils.spectral_frequencies`, which reads the *low-level* WCS: it returns **Hz** whatever `CUNIT` says, takes the channel count from whichever axis the WCS calls spectral, and needs no observation time. That last point matters -- the high-level WCS refuses to convert pixels to frequencies without a usable obstime, which is why this used to resolve the epoch and stamp it into a header copy first. `plan_cube_doppler` now resolves the epoch for the Doppler factor alone.
+
+`FitsHeader.retFreq()` is the same grid in **MHz**, and exists for the fitters: `FitFunc.prepare` converts back with `self.freqs * 1e6`, and `FitPolynomial` runs `numpy.polyfit` against those values, where the scale sets the conditioning. Measuring a frequency wants `spectral_frequencies`; fitting against one wants `retFreq`. Do not swap them.
+
+`FITS_SPECSYS` (FITS keyword names) and `FRAME_CODES` (MS integer codes) describe the same frames for different formats and must not be substituted for one another.
 
 Constants and the composition of conversion steps are taken from casacore's `MeasTable`/`MCFrequency`, so grids agree with CASA. Two details are load-bearing:
 

--- a/src/mowjsub/utils.py
+++ b/src/mowjsub/utils.py
@@ -180,40 +180,54 @@ def subtract_fits(data_file: File, model_file: File, hdu_idx: int, ra_chunks: in
     return fitsio.PrimaryHDU(out_ds.hdu.data, header=header)
 
 
+def spectral_frequencies(header):
+    """Channel frequencies of a cube, in Hz.
+
+    The grid is read through the *low-level* WCS, which is what makes this
+    independent of two things the previous implementation was tied to. It
+    returns SI regardless of ``CUNIT``, so there is no unit to guess; and it
+    converts pixels to frequencies without an observation time, where the
+    high-level WCS refuses to do so at all. The spectral axis is whichever one
+    the WCS says it is, rather than ``NAXIS3``.
+
+    Args:
+        header: FITS header of a spectral cube.
+
+    Returns:
+        np.ndarray: Channel frequency in Hz, one per channel.
+
+    Raises:
+        RuntimeError: The header describes no spectral axis.
+    """
+    wcs = WCS(header)
+    axis = wcs.wcs.spec
+    if axis < 0:
+        raise RuntimeError("This cube has no spectral axis.")
+
+    nchan = int(header[f"NAXIS{axis + 1}"])
+
+    return np.asarray(wcs.spectral.array_index_to_world_values(np.arange(nchan)), dtype=float)
+
+
 class FitsHeader:
     def __init__(self, header: Dict):
         self._header = header.copy()
 
     def retFreq(self):
-        """
-        Extract the part of the cube name that will be used in the name of
-        the averaged cube
+        """Channel frequencies in MHz.
 
-        Parameters
-        ----------
-        header : `~astropy.io.fits.Header`
-            header object from the fits file
+        MHz rather than Hz because the fitters work in it: ``FitFunc.prepare``
+        converts back with ``self.freqs * 1e6`` for :func:`chans_in_velwidth`,
+        and ``FitPolynomial`` fits ``numpy.polyfit`` against these values, where
+        the scale decides the conditioning. Anything measuring a frequency
+        rather than fitting against one wants :func:`spectral_frequencies`.
 
         Returns
         -------
         frequency
             a 1D numpy array of channel frequencies in MHz
         """
-
-        if "TIMESYS" not in self._header:
-            self._header["TIMESYS"] = "utc"
-        elif self._header["TIMESYS"] != "utc":
-            self._header["TIMESYS"] = "utc"
-        freqDim = self._header["NAXIS3"]
-        wcs3d = WCS(self._header)
-        try:
-            wcsfreq = wcs3d.spectral
-        except:  # noqa: E722 TODO(Mika) fix this
-            wcsfreq = wcs3d.sub(["spectral"])
-        return np.around(
-            wcsfreq.pixel_to_world(np.arange(0, freqDim)).to(units.MHz).value,
-            decimals=7,
-        )
+        return np.around(spectral_frequencies(self._header) / 1e6, decimals=7)
 
     def getAppendHeader(self, nchan):
         return self.spectralSplitHeader(nchan, orig="append_fits")
@@ -627,10 +641,12 @@ def cube_spectral_axis(header):
     if spec < 0:
         raise RuntimeError("This cube has no spectral axis, so there is nothing to Doppler-correct.")
 
-    # A stricter check than the Doppler code alone needs. FitsHeader.retFreq
-    # reads NAXIS3 directly and im-mowjsub writes its continuum back assuming
-    # RA, DEC, FREQ[, STOKES], so a cube with the spectral axis elsewhere fails
-    # confusingly during the fit, long before reaching this point. Say so.
+    # A stricter check than either the Doppler code or the spectral grid needs:
+    # both derive the axis from the WCS and are order-agnostic. What is not is
+    # the continuum write-back in im_mowjsub.runit, which transposes to a fixed
+    # (2, 1, 0) and puts Stokes outermost. Until that places its axes by WCS
+    # too, a cube with the spectral axis elsewhere would fail confusingly on the
+    # way out rather than here. Say so up front instead.
     if spec != 2:
         raise RuntimeError(f"mowjsub needs the spectral axis on NAXIS3; this cube has it on NAXIS{spec + 1}. Reorder the axes (e.g. with CASA imtrans) and try again.")
 
@@ -750,16 +766,13 @@ def plan_cube_doppler(
     location = _cube_location(header, telescope)
     epoch = _cube_time(header, obs_time)
 
-    # retFreq reads the grid through astropy's high-level WCS, which insists on a
-    # usable observation time even to convert pixels to frequencies. Hand it the
-    # epoch resolved above, so --doppler-time rescues a header that lacks one
-    # instead of failing deep inside astropy.
-    spectral_header = fitsio.Header(header)
-    spectral_header["MJD-OBS"] = epoch / 86400.0
-
-    # retFreq works in MHz; everything in doppler.py that is not scale-free
-    # (parse_channel_grid) works in Hz, so normalise here.
-    freqs_in = np.asarray(FitsHeader(spectral_header).retFreq(), dtype=float) * 1e6
+    # Hz throughout, which is what everything in doppler.py that is not
+    # scale-free (parse_channel_grid) works in. This used to go through retFreq,
+    # which meant converting from MHz and stamping the resolved epoch into a
+    # header copy first -- the high-level WCS it used insists on a usable
+    # observation time even to turn pixels into frequencies. Neither is needed
+    # now; the epoch below is for the Doppler factor alone.
+    freqs_in = spectral_frequencies(header)
 
     if frame == "source" and source_vel is None:
         raise RuntimeError("--doppler-frame=source needs a systemic velocity, and a cube carries none. Pass --doppler-source-vel.")

--- a/tests/test_doppler_image.py
+++ b/tests/test_doppler_image.py
@@ -15,7 +15,13 @@ from click.testing import CliRunner
 
 from mowjsub.doppler import FITS_SPECSYS, resample_cube
 from mowjsub.parser.im_mowjsub import runit
-from mowjsub.utils import apply_cube_doppler, cube_spectral_axis, plan_cube_doppler
+from mowjsub.utils import (
+    FitsHeader,
+    apply_cube_doppler,
+    cube_spectral_axis,
+    plan_cube_doppler,
+    spectral_frequencies,
+)
 
 # MeerKAT, as ITRF metres, matching tests/test_doppler.py.
 MEERKAT = (5109360.133, 2006852.586, -3238948.127)
@@ -24,11 +30,13 @@ MEERKAT = (5109360.133, 2006852.586, -3238948.127)
 def _header(nchan=32, f0=1.4e9, df=1e6, npix=4, stokes=False, spectral_axis=3):
     """A minimal but WCS-complete spectral cube header.
 
-    NAXIS* are set explicitly because ``FitsHeader.retFreq`` reads ``NAXIS3``
-    straight off the header, without a data array to infer it from.
+    NAXIS* are set explicitly because there is no data array to infer the
+    channel count from; ``spectral_frequencies`` reads it off the header, for
+    whichever axis the WCS says is spectral.
 
-    ``spectral_axis=4`` puts STOKES on NAXIS3 and FREQ on NAXIS4, the layout
-    mowjsub does not support; it exists here only to pin the refusal.
+    ``spectral_axis=4`` puts STOKES on NAXIS3 and FREQ on NAXIS4. The spectral
+    grid handles that layout; ``im-mowjsub`` as a whole still refuses it,
+    because the continuum write-back places its axes by fixed transpose.
     """
     header = fitsio.Header()
     header["CTYPE1"] = "RA---SIN"
@@ -91,7 +99,13 @@ class TestSpectralAxis(unittest.TestCase):
         assert cube_spectral_axis(_header()) == 2
 
     def test_a_spectral_axis_elsewhere_is_refused(self):
-        """Stated limitation: retFreq and the continuum writeback assume NAXIS3."""
+        """Stated limitation: the continuum write-back assumes NAXIS3.
+
+        The spectral grid no longer does -- see
+        ``TestSpectralFrequencies.test_a_swapped_axis_order_is_read_correctly``
+        -- so this guard is all that stands between a swapped cube and the fixed
+        transpose in ``im_mowjsub.runit``.
+        """
         with self.assertRaises(RuntimeError) as raised:
             cube_spectral_axis(_header(spectral_axis=4))
 
@@ -107,6 +121,62 @@ class TestSpectralAxis(unittest.TestCase):
             cube_spectral_axis(header)
 
         assert "no spectral axis" in str(raised.exception)
+
+
+class TestSpectralFrequencies(unittest.TestCase):
+    """The channel grid, read through the low-level WCS.
+
+    Its predecessor -- ``FitsHeader.retFreq`` reading ``NAXIS3`` through the
+    high-level WCS -- was wrong in two ways that these pin: it took the channel
+    count from a fixed axis, and it could not produce a grid at all without an
+    observation time.
+    """
+
+    def test_the_grid_matches_crval_and_cdelt(self):
+        freqs = spectral_frequencies(_header(nchan=32, f0=1.4e9, df=1e6))
+
+        assert freqs.size == 32
+        np.testing.assert_allclose(freqs, 1.4e9 + np.arange(32) * 1e6, rtol=1e-12)
+
+    def test_a_swapped_axis_order_is_read_correctly(self):
+        """STOKES on NAXIS3, FREQ on NAXIS4: the layout that used to give 1 channel."""
+        header = _header(nchan=32, spectral_axis=4)
+        assert header["NAXIS3"] == 1, "the Stokes length the old code would have used"
+
+        freqs = spectral_frequencies(header)
+
+        assert freqs.size == 32
+        np.testing.assert_allclose(freqs, 1.4e9 + np.arange(32) * 1e6, rtol=1e-12)
+
+    def test_no_observation_time_is_needed(self):
+        header = _header()
+        for key in ("DATE-OBS", "MJD-OBS", "TIMESYS"):
+            header.pop(key, None)
+
+        np.testing.assert_allclose(spectral_frequencies(header), 1.4e9 + np.arange(32) * 1e6, rtol=1e-12)
+
+    def test_a_non_si_cunit_still_yields_hz(self):
+        """CUNIT is the header's business; this returns SI either way."""
+        header = _header()
+        header["CUNIT3"], header["CRVAL3"], header["CDELT3"] = "MHz", 1400.0, 1.0
+
+        np.testing.assert_allclose(spectral_frequencies(header), 1.4e9 + np.arange(32) * 1e6, rtol=1e-12)
+
+    def test_a_cube_with_no_spectral_axis_is_refused(self):
+        header = _header()
+        for key in ("CTYPE3", "CRVAL3", "CDELT3", "CRPIX3", "CUNIT3"):
+            header.pop(key, None)
+
+        with self.assertRaises(RuntimeError) as raised:
+            spectral_frequencies(header)
+
+        assert "no spectral axis" in str(raised.exception)
+
+    def test_ret_freq_is_the_same_grid_in_mhz(self):
+        """The fitters work in MHz; keep the two definitions tied together."""
+        header = _header()
+
+        np.testing.assert_allclose(FitsHeader(header).retFreq(), spectral_frequencies(header) / 1e6, rtol=1e-12)
 
 
 class TestPlan(unittest.TestCase):
@@ -165,7 +235,12 @@ class TestPlan(unittest.TestCase):
         assert "doppler-time" in str(raised.exception)
 
     def test_doppler_time_rescues_a_header_with_no_epoch(self):
-        """retFreq needs an obstime of its own, so the override must reach it."""
+        """The epoch is needed for the Doppler factor, and only for that.
+
+        It used to be needed for the channel grid as well, which is why the
+        override had to be resolved before the grid was read. The grid no longer
+        cares; this pins that the factor still honours the override.
+        """
         header = _header()
         header.pop("DATE-OBS", None)
 


### PR DESCRIPTION
First slice of the fitstoolz adoption (handover item 1). It closes the *grid*
half; the continuum write-back is the other half and is untouched here.

## What was wrong

`FitsHeader.retFreq` took the channel count off `NAXIS3` and evaluated the grid
through astropy's **high-level** WCS. Both cost something:

- **`NAXIS3`** meant a cube with `CTYPE3=STOKES, CTYPE4=FREQ` — a legal layout,
  and one CASA `exportfits` produces — reported the Stokes axis length. The grid
  came back with **1 channel instead of 32**.
- **The high-level WCS** insists on a usable obstime even to turn pixels into
  frequencies, so `plan_cube_doppler` had to resolve the epoch up front and stamp
  it into a header copy before it could read a grid at all.

Both are the traps written up in `AGENTS.md`.

## What replaces it

`utils.spectral_frequencies(header)` reads the **low-level** WCS:

| | before | after |
|---|---|---|
| channel count | `NAXIS3` | whichever axis the WCS calls spectral |
| units | MHz (implicit) | Hz, whatever `CUNIT` says |
| obstime | required | not involved |

`plan_cube_doppler` now resolves the epoch for the Doppler factor alone, and the
header copy and the `* 1e6` are both gone.

**`retFreq` stays**, delegating to it, because MHz is not an accident there:
`FitFunc.prepare` converts back with `self.freqs * 1e6`, and `FitPolynomial` runs
`numpy.polyfit` against those values, where the scale sets the conditioning.
Moving the fitters to Hz is a numerical change and doesn't belong in this PR.

## What is deliberately *not* changed

`im-mowjsub` still refuses a spectral axis anywhere but `NAXIS3`. That guard is
now the **only** thing refusing it — the grid handles the layout and
`apply_cube_doppler` was always order-agnostic — but `im_mowjsub.runit` still
transposes the continuum to a fixed `(2, 1, 0)` and puts Stokes outermost, so a
swapped cube would fail confusingly on the way out. The refusal stays until that
places its axes by WCS too. `cube_spectral_axis`'s comment now says so.

## On fitstoolz

This does not add the dependency. `FitsData` is path-based and
`plan_cube_doppler` is header-based, driven by 18 bare-header calls in the tests
— threading paths through would mean writing cubes in unit tests, and keeping a
second grid implementation alongside fitstoolz's is exactly the duplication that
produced the unit bugs fixed upstream last week.

`spectral_frequencies` is deliberately the same technique `FitsData` uses
internally, and it disappears at stage 2, where `FitsData.get_xds` /
`write_to_fits(coord_names=...)` replace `zds_from_fits` and the transpose
together — which is also what closes the other half of item 1.

## Verification

- 81 tests pass, 1 skipped (was 75/1). Lint and format clean.
- The two new tests that matter were checked against the old implementation:
  `test_a_swapped_axis_order_is_read_correctly` and
  `test_no_observation_time_is_needed` both fail against it.
- `TestSpectralFrequencies` also pins Hz output for an MHz header, the refusal
  when there is no spectral axis, and that `retFreq` stays the same grid in MHz.

`AGENTS.md` (and `.claude/CLAUDE.md`, which is a symlink to it) no longer
describes the two traps as live, and states which of the two frequency accessors
to reach for.
