### PR TITLE
Form the residual from arrays, and write both cubes in one pass

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,13 +116,18 @@ Available fitters:
 
 ```
 im_mowjsub.py:runit
-  └─ zds_from_fits()          # FITS → xr.Dataset with FREQS coord
+  └─ zds_from_fits()          # FITS → xr.Dataset, via fitstoolz.FitsData
   └─ [optional] get_automask() # sigma-clip automask using ContSub + PixSigmaClip
   └─ da.gufunc(ContSub.fitContinuum)  # Dask parallel over RA blocks
-  └─ subtract_fits()          # data − continuum → line cube
+  └─ line = data − continuum  # an array op, in the file's own axis order
+  └─ write_cubes()            # both cubes, one pass over the graph
 ```
 
 `ContSub.fitContinuum` iterates over all `(ra, dec)` pixels, calling `fitfunc.fit` on each 1D spectrum.
+
+**Both cubes are written in one `da.store`, and that is load-bearing.** They share the per-pixel fit, which is the expensive part of a run; a `writeto` each makes dask walk that graph twice and refit every spectrum — measured at 2x on a 128×128×256 cube. `utils.write_cubes` reserves each output on disk with `allocate_fits` and streams into the memory map, so neither cube is held whole either. If you add a third output derived from the same fit, add it to the same `write_cubes` call rather than writing it separately.
+
+This replaced a `subtract_fits` that took *paths*: it wrote the continuum, then read it straight back alongside the input to form the residual from arrays the caller already had. The Doppler path had to stage a topocentric continuum in `{prefix}-cont-topo.fits` and delete it in a `finally`, purely to satisfy that. Both are gone, and with them the last use of `xarray-fits`, which is no longer a dependency.
 
 ### CLI parameter schemas
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ dependencies = [
 	"numpy",
 	"astropy",
 	"scipy",
-	"xarray-fits",
 	"xarray",
 	"scabha>=2.2.0rc2",
 	"zarr",

--- a/src/mowjsub/parser/im_mowjsub.py
+++ b/src/mowjsub/parser/im_mowjsub.py
@@ -2,7 +2,6 @@ import glob
 import os
 import time
 
-import astropy.io.fits as fitsio
 import click
 import dask
 import dask.array as da
@@ -27,7 +26,7 @@ from mowjsub.utils import (
     apply_cube_doppler,
     get_automask,
     plan_cube_doppler,
-    subtract_fits,
+    write_cubes,
     zds_from_fits,
 )
 
@@ -179,26 +178,16 @@ def runit(**kwargs):
 
     header = zds.attrs["header"]
 
+    # The residual is an array operation now, on the cube already in hand and in
+    # the file's own axis order. It used to be formed by writing the continuum
+    # out and reading it straight back alongside the input -- which is also why
+    # the Doppler path needed a `{prefix}-cont-topo.fits` scratch file, since the
+    # continuum had to exist on disk before the residual could be taken.
+    line = zds.DATA.transpose(*zds.attrs["fits_dims"]).data - continuum
+
     if not opts.doppler_frame:
-        out_ds_cont = fitsio.PrimaryHDU(continuum, header=header)
-
-        out_ds_cont.writeto(outcont.PATH, overwrite=opts.overwrite)
-        log.info(f"Continuum model cube written to: {outcont}")
-
-        out_ds_line = subtract_fits(
-            infits.PATH,
-            outcont.PATH,
-            hdu_idx=opts.hdu_index,
-            ra_chunks=ra_chunks,
-        )
-        log.info(f"Writing residual data (line cube) to: {outline}")
-        out_ds_line.writeto(outline.PATH, overwrite=opts.overwrite)
+        outputs = [(outcont.PATH, continuum, header), (outline.PATH, line, header)]
     else:
-        # subtract_fits reads its continuum back off disk, so the topocentric
-        # model has to exist as a file before the residual can be formed. Stage
-        # it beside the outputs rather than writing outcont twice: --overwrite
-        # is checked once, against files from previous runs, so a second write
-        # to outcont would either trip that check or have to bypass it.
         source_vel = opts.doppler_source_vel
         plan = plan_cube_doppler(
             header,
@@ -211,28 +200,18 @@ def runit(**kwargs):
             source_vel=None if source_vel is None else source_vel * 1e3,
         )
 
-        scratch = File(f"{prefix}-cont-topo.fits")
-        fitsio.PrimaryHDU(continuum, header=header).writeto(scratch.PATH, overwrite=True)
-        try:
-            line_hdu = subtract_fits(
-                infits.PATH,
-                scratch.PATH,
-                hdu_idx=opts.hdu_index,
-                ra_chunks=ra_chunks,
-            )
+        # One plan for both cubes, so the pair stays on a single grid and
+        # remains recombinable.
+        outputs = [
+            (outcont.PATH, *apply_cube_doppler(continuum, header, plan, opts.doppler_interpolation)),
+            (outline.PATH, *apply_cube_doppler(line, header, plan, opts.doppler_interpolation)),
+        ]
 
-            # One plan for both cubes, so the pair stays on a single grid and
-            # remains recombinable.
-            cont_data, cont_header = apply_cube_doppler(continuum, header, plan, opts.doppler_interpolation)
-            fitsio.PrimaryHDU(cont_data, header=cont_header).writeto(outcont.PATH, overwrite=opts.overwrite)
-            log.info(f"Continuum model cube written to: {outcont}")
-
-            line_data, line_header = apply_cube_doppler(line_hdu.data, line_hdu.header, plan, opts.doppler_interpolation)
-            log.info(f"Writing residual data (line cube) to: {outline}")
-            fitsio.PrimaryHDU(line_data, header=line_header).writeto(outline.PATH, overwrite=opts.overwrite)
-        finally:
-            if os.path.exists(scratch.PATH):
-                os.remove(scratch.PATH)
+    log.info(f"Writing continuum model cube to: {outcont}")
+    log.info(f"Writing residual data (line cube) to: {outline}")
+    # Both cubes in one pass: they share the per-pixel fit, and a writeto each
+    # would make dask walk that graph twice and refit every spectrum.
+    write_cubes(outputs, overwrite=opts.overwrite)
 
     # DONE
     dtime = time.time() - start_time

--- a/src/mowjsub/utils.py
+++ b/src/mowjsub/utils.py
@@ -1,4 +1,5 @@
 import datetime
+import os
 import warnings
 from collections import namedtuple
 from typing import Dict
@@ -15,9 +16,7 @@ from casacore.tables import table
 from daskms import Dataset, xds_from_ms, xds_from_table
 from fitstoolz.reader import FitsData
 from scabha import init_logger
-from scabha.basetypes import File
 from tqdm.dask import TqdmCallback
-from xarrayfits import xds_from_fits
 
 from mowjsub import BIN
 from mowjsub.doppler import (
@@ -174,34 +173,81 @@ def zds_from_fits(fname, chunks=None, rest_freq=None, hdu_idx=0, add_freqs=False
         )
 
 
-def subtract_fits(data_file: File, model_file: File, hdu_idx: int, ra_chunks: int = None):
-    """Returns the residual of two FITS files as a FitsPrimaryHDU object
+#: FITS lays a file out in blocks of this many bytes, data unit included.
+FITS_BLOCK = 2880
+
+
+def allocate_fits(path, shape, dtype, header, overwrite=False):
+    """Create a FITS file of the right size, open for writing a chunk at a time.
+
+    The data unit is reserved on disk rather than built in memory, so a caller
+    holding a lazy cube can stream into ``hdulist[0].data`` without ever having
+    the whole thing.
 
     Args:
-        data_file (File): FITS file of the data
-        model_file (File): FITS file of model data
-        hdu_idx (int): FITS HDU index
-        ra_chunks (int): Chunk size along the RA axis. Zero or unset reads the cube as a single chunk.
+        path (str): File to create.
+        shape (tuple): Array shape, in numpy (C) order.
+        dtype: Element type.
+        header: Header to base the output on; ``NAXIS*`` are set from ``shape``.
+        overwrite (bool): Replace an existing file.
 
     Returns:
-        FitsPrimaryHDU
+        astropy.io.fits.HDUList: Open in update mode, memory-mapped.
+
+    Raises:
+        OSError: ``path`` exists and ``overwrite`` is False.
     """
+    if os.path.exists(path):
+        if not overwrite:
+            raise OSError(f"Output file '{path}' already exists.")
+        os.remove(path)
 
-    # xarrayfits chunk keys are C-order axis indices, and RA is NAXIS1, i.e. the
-    # fastest-varying FITS axis. In C order that is the last axis, whatever the
-    # cube's dimensionality. Unlisted axes are read as a single chunk.
-    ndim = fitsio.getheader(data_file, hdu_idx)["NAXIS"]
-    chunks = {ndim - 1: ra_chunks} if ra_chunks else {}
+    # A one-element stub only so astropy derives BITPIX from the dtype; the
+    # dimensions are then stated for the real array.
+    out = fitsio.PrimaryHDU(data=np.zeros((1,) * len(shape), dtype=dtype), header=header).header
+    out["NAXIS"] = len(shape)
+    for index, length in enumerate(reversed(shape), start=1):
+        out[f"NAXIS{index}"] = int(length)
+    out.tofile(path)
 
-    data_ds = xds_from_fits(data_file, hdus=hdu_idx, chunks=chunks)[0]
-    model_ds = xds_from_fits(model_file, hdus=hdu_idx, chunks=chunks)[0]
-    residual_ds = data_ds.hdu.data - model_ds.hdu.data
+    nbytes = int(np.prod(shape)) * np.dtype(dtype).itemsize
+    # Pad the data unit to a whole block: a file that stops short of one reads
+    # back as truncated.
+    reserved = -(-nbytes // FITS_BLOCK) * FITS_BLOCK
+    with open(path, "rb+") as handle:
+        handle.seek(len(out.tostring()) + reserved - 1)
+        handle.write(b"\0")
 
-    out_ds = data_ds.assign(
-        hdu=(data_ds.hdu.dims, residual_ds, data_ds.hdu.attrs),
-    )
-    header = fitsio.Header(data_ds.hdu.header)
-    return fitsio.PrimaryHDU(out_ds.hdu.data, header=header)
+    return fitsio.open(path, mode="update", memmap=True)
+
+
+def write_cubes(outputs, overwrite=False):
+    """Write several cubes to FITS in a single pass over the dask graph.
+
+    The continuum and the residual come from the same per-pixel fit, and that
+    fit is the expensive part of a run. Writing them with a ``writeto`` each
+    makes dask walk the graph once per file and refit every spectrum -- measured
+    at 2x on a 128x128x256 cube. One ``da.store`` shares the work, and streams
+    it, so neither cube is ever held whole.
+
+    This replaced a ``subtract_fits`` that took *paths*: the continuum was
+    written, then read straight back alongside the input to form the residual
+    from arrays the caller already had. The Doppler path had to stage a
+    topocentric continuum in a scratch file to satisfy it.
+
+    Args:
+        outputs (list): One ``(path, array, header)`` per cube.
+        overwrite (bool): Replace existing files.
+    """
+    handles = []
+    try:
+        for path, array, header in outputs:
+            handles.append(allocate_fits(path, array.shape, array.dtype, header, overwrite=overwrite))
+
+        da.store([array for _, array, _ in outputs], [handle[0].data for handle in handles])
+    finally:
+        for handle in handles:
+            handle.close()
 
 
 def spectral_frequencies(header):

--- a/tests/test_doppler_image.py
+++ b/tests/test_doppler_image.py
@@ -393,12 +393,26 @@ class TestEndToEnd(unittest.TestCase):
         for key in ("NAXIS3", "CRVAL3", "CDELT3", "CRPIX3", "SPECSYS"):
             assert headers[0][key] == headers[1][key], key
 
-    def test_the_scratch_continuum_is_cleaned_up(self):
+    def test_no_scratch_continuum_is_written(self):
+        """The residual is taken from arrays, so nothing is staged on disk.
+
+        The Doppler path used to write a topocentric continuum to
+        ``{prefix}-cont-topo.fits`` and delete it in a ``finally``, because the
+        residual was formed by re-reading the continuum off disk.
+        """
         result, _, _ = self._run("--doppler-frame", "bary")
         assert result.exit_code == 0, result.output
 
         assert not (self.tmpdir / "out-cont-topo.fits").exists()
         assert sorted(p.name for p in self.tmpdir.glob("*.fits")) == ["cube.fits", "out-cont.fits", "out-line.fits"]
+
+    def test_the_continuum_and_line_add_back_up(self):
+        """Whatever else the pair go through, they have to sum to the input."""
+        result, cont, line = self._run()
+        assert result.exit_code == 0, result.output
+
+        source = fitsio.getdata(self.cube)
+        np.testing.assert_allclose(fitsio.getdata(cont) + fitsio.getdata(line), source, rtol=1e-5, atol=1e-5)
 
     def test_explicit_grid_is_honoured(self):
         result, _, line = self._run("--doppler-frame", "lsrk", "--doppler-chan-grid", "20,1405MHz,1MHz")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,10 +1,13 @@
+import os
 import shutil
 import tempfile
 import unittest
+import warnings
 from pathlib import Path
 
 import astropy.io.fits as fitsio
 import dask
+import dask.array as da
 import numpy as np
 from scabha import init_logger
 
@@ -217,3 +220,72 @@ class TestZdsFromFits(unittest.TestCase):
         zds = utils.zds_from_fits(path, rest_freq=1420.40575)
 
         assert zds.attrs["header"]["RESTFREQ"] == 1420.40575 * 1e6
+
+
+class TestWriteCubes(unittest.TestCase):
+    """Writing several cubes in one pass over the graph."""
+
+    def setUp(self):
+        self.tmpdir = Path(tempfile.mkdtemp())
+        self.header = fitsio.Header()
+        for index, (ctype, crval, cdelt, cunit) in enumerate([("RA---SIN", 20.0, -1e-3, "deg"), ("DEC--SIN", -30.0, 1e-3, "deg"), ("FREQ", 1.4e9, 1e6, "Hz")], start=1):
+            self.header[f"CTYPE{index}"], self.header[f"CRVAL{index}"] = ctype, crval
+            self.header[f"CDELT{index}"], self.header[f"CUNIT{index}"], self.header[f"CRPIX{index}"] = cdelt, cunit, 1
+        self.header["BUNIT"], self.header["SPECSYS"] = "Jy/beam", "TOPOCENT"
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def test_both_cubes_round_trip_with_their_headers(self):
+        one = da.arange(8 * 4 * 4, chunks=(32,), dtype="f4").reshape(8, 4, 4)
+        two = one * -1
+        paths = [self.tmpdir / "a.fits", self.tmpdir / "b.fits"]
+
+        utils.write_cubes([(str(paths[0]), one, self.header), (str(paths[1]), two, self.header)])
+
+        for path, expected in zip(paths, (one, two)):
+            with warnings.catch_warnings():
+                warnings.simplefilter("error")  # a short data unit reads back as truncated
+                np.testing.assert_allclose(fitsio.getdata(path), np.asarray(expected))
+            header = fitsio.getheader(path)
+            assert header["NAXIS3"], header["NAXIS1"] == (8, 4)
+            assert header["BUNIT"] == "Jy/beam"
+            assert header["SPECSYS"] == "TOPOCENT"
+
+    def test_shared_work_is_computed_once(self):
+        """Both outputs come off one fit; two writeto calls would refit."""
+        calls = []
+
+        def expensive(block):
+            if block.size:  # dask calls once with an empty block to infer meta
+                calls.append(block.shape)
+            return block * 2
+
+        source = da.ones((4, 4, 4), chunks=(2, 4, 4), dtype="f4")
+        shared = source.map_blocks(expensive, dtype="f4")
+        utils.write_cubes(
+            [
+                (str(self.tmpdir / "c.fits"), shared, self.header),
+                (str(self.tmpdir / "d.fits"), shared + 1, self.header),
+            ]
+        )
+
+        assert len(calls) == source.numblocks[0], f"expected one call per block, got {len(calls)}"
+
+    def test_an_existing_file_is_refused_unless_overwrite(self):
+        path = self.tmpdir / "e.fits"
+        array = da.zeros((2, 4, 4), chunks=-1, dtype="f4")
+        utils.write_cubes([(str(path), array, self.header)])
+
+        with self.assertRaises(OSError):
+            utils.write_cubes([(str(path), array, self.header)])
+
+        utils.write_cubes([(str(path), array + 5, self.header)], overwrite=True)
+        np.testing.assert_allclose(fitsio.getdata(path), 5.0)
+
+    def test_the_data_unit_is_block_aligned(self):
+        """A file that stops short of a 2880-byte block reads back as truncated."""
+        for shape in ((7, 13, 5), (1, 32, 4, 4)):
+            path = self.tmpdir / f"pad{len(shape)}{shape[0]}.fits"
+            utils.write_cubes([(str(path), da.zeros(shape, chunks=-1, dtype="f4"), self.header)], overwrite=True)
+            assert os.path.getsize(path) % utils.FITS_BLOCK == 0, shape

--- a/uv.lock
+++ b/uv.lock
@@ -506,7 +506,6 @@ dependencies = [
     { name = "scipy", version = "1.18.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "tqdm" },
     { name = "xarray" },
-    { name = "xarray-fits" },
     { name = "zarr", version = "3.1.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "zarr", version = "3.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
@@ -535,7 +534,6 @@ requires-dist = [
     { name = "scipy" },
     { name = "tqdm" },
     { name = "xarray" },
-    { name = "xarray-fits" },
     { name = "zarr" },
 ]
 
@@ -1480,21 +1478,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ea/96/3f7bdd00e505ec3698903415b30135024703e017b28c6b61f98da3193b0d/xarray-2026.7.0.tar.gz", hash = "sha256:361b495928fdbf5b58d0969bb6775339019da5e93ca74d61ddf4eb5edd6ce604", size = 3145348, upload-time = "2026-07-09T17:38:26.515Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/57/5b/28365212062939d213802e5e5fe855cdb231e1c2a93254ba1690066504e3/xarray-2026.7.0-py3-none-any.whl", hash = "sha256:bf9dd130b93806dc78e90c1b7ac24851b31557b888674c53622235691cf21824", size = 1426778, upload-time = "2026-07-09T17:38:24.224Z" },
-]
-
-[[package]]
-name = "xarray-fits"
-version = "0.2.6"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "astropy" },
-    { name = "dask", extra = ["array"] },
-    { name = "fsspec" },
-    { name = "xarray" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/53/10/d51c64b219e034348d5d15dc0232179392c2501a181b5525a452487b9624/xarray_fits-0.2.6.tar.gz", hash = "sha256:f5291b0677c1aa831018ff3de78720197c69beeb8a43cf335fea43f4dbed9827", size = 16480, upload-time = "2026-02-26T13:40:11.605Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/83/0c/15b29823e23e96627023b191e24109668cd51ce9d3c95a891221a0d37ead/xarray_fits-0.2.6-py3-none-any.whl", hash = "sha256:964837d3a2f6ec98b008120b2ff9910871992a0e7d54f244e2d622a321e7216d", size = 8814, upload-time = "2026-02-26T13:40:10.598Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Stage 3 of the fitstoolz adoption, and the close of **handover item 2**.

## What was there

`subtract_fits` took *paths*. It wrote the continuum out, then read it straight
back alongside the input to subtract arrays the caller already had. The Doppler
path had to stage a topocentric continuum in `{prefix}-cont-topo.fits` and delete
it in a `finally`, purely to satisfy that — and the `--overwrite` dance in the
handover note existed only because of the scratch file.

The residual is now `data - continuum`, in the file's own axis order. The scratch
file, the `finally`, and the `--overwrite` interaction are all gone: each output
is written exactly once, in both branches.

## What the handover note missed

This is most of the work. **The continuum feeds both outputs**, so writing them
with a `writeto` each makes dask walk that graph twice and **refit every
spectrum**. Measured on a 128×128×256 cube:

```
continuum alone                 9.16s
continuum then line (2 walks)  18.14s   <- what a naive array refactor gives you
both in one walk                8.99s
penalty                         2.02x
```

The disk round-trip being removed was, by accident, caching the fit.

So `write_cubes` writes every output in a **single `da.store`**. `allocate_fits`
reserves each file at full size on disk — header, then a data unit padded to a
whole 2880-byte block, since a file that stops short of one reads back as
truncated — and dask streams into the memory map, so no cube is held whole
either.

## Net effect

| | before | after |
|---|---|---|
| runtime (128×128×256, poly order 2) | 12.2s | **7.9s** |
| peak RSS | 341 MB | **306 MB** |
| files written | 3 (incl. scratch, Doppler path) | 2 |

`cont + line` still sums to the input exactly, and the injected line comes back at
the same channel and amplitude.

`xarray-fits` was left with no users once `subtract_fits` went, so it is no longer
a dependency — fitstoolz reads the cubes, astropy writes them.

## Verification

- 92 tests pass, 1 skipped (was 87/1). Lint, format and docs clean.
- `test_shared_work_is_computed_once` counts fit invocations: 2 with the shared
  store, 4 if you split it into a store per output (checked by mutation).
- `test_the_data_unit_is_block_aligned` covers shapes that do not land on a
  block boundary; without the padding astropy reads the file back as truncated.
- `test_no_scratch_continuum_is_written` replaces the old
  `test_the_scratch_continuum_is_cleaned_up` — nothing is staged now, rather than
  staged and removed.
- New `test_the_continuum_and_line_add_back_up` pins the invariant directly.
- Ran the real CLI on both paths: plain, and `--doppler-frame bary` (both cubes
  land on the same 253-channel `BARYCENT` grid, no scratch file left behind).

## Remaining

Handover items 3 (`common_channel_grid` floating point) and 4 (caracal2
coordination) are untouched and independent of this line of work.
