### PR TITLE
Snap the auto channel grid to the integer before flooring

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,29 @@ project's former name, **contsub**.
 
 ## Unreleased (2.0rc2)
 
+### Fixed
+
+- **An `auto` Doppler channel grid no longer loses a channel to floating point.**
+  `common_channel_grid` derives the output length by dividing the common span by
+  the channel width and flooring. When every timestamp shares one Doppler factor
+  — always true of a cube, and effectively true of a short track — that factor
+  cancels out of the ratio, so the span is a whole number of channels in real
+  arithmetic. Multiplying ~1e9 Hz by the factor first leaves the division a few
+  ULPs either side of the integer, and on the low side `floor` charged a whole
+  channel for the rounding.
+
+  The result was an `auto` grid of `nchan_in - 3` instead of the intended
+  `nchan_in - 2`, for **about half of all factors**, with no way to predict
+  which. The ratio is now snapped to the integer when it is within 1e-6 of one;
+  the observed error is ~4e-13 channels, and a real drift falls whole channels
+  short, not a millionth of one.
+
+  **This changes output channel counts.** A grid that came out one channel short
+  now comes out at its intended width — one channel wider than the same run
+  produced before. No data moves: the grid was guard-trimmed either way, and
+  both edges stay strictly inside the shifted band. `vis-mowjsub` and
+  `im-mowjsub` are affected identically, as is `doppler-mowjsub`.
+
 ### Changed
 
 - **`vis-mowjsub --output-column` no longer defaults to `LINE_DATA`.** It is now

--- a/src/mowjsub/doppler.py
+++ b/src/mowjsub/doppler.py
@@ -220,7 +220,26 @@ def common_channel_grid(freqs, factors):
     chan0 += width
     chanl -= width
 
-    nchan = int(np.floor((chanl - chan0) / width)) + 1
+    steps = (chanl - chan0) / width
+
+    # Snap to the integer before flooring. When every timestamp shares one
+    # Doppler factor -- which is always true of a cube, and true of a short
+    # track -- the factor cancels out of this ratio, so the span is a whole
+    # number of channels in real arithmetic. Multiplying ~1e9 Hz by the factor
+    # first leaves the division a few ULPs either side of it, and on the low
+    # side floor() charges a whole channel for the rounding: an `auto` grid came
+    # out `nchan_in - 3` instead of `nchan_in - 2` for about half of all
+    # factors, unpredictably.
+    #
+    # The observed error is ~4e-13 channels, so a tolerance of 1e-6 is orders of
+    # magnitude clear of the noise while staying far below any trimming that
+    # means anything -- and a real drift lands whole channels short of the
+    # integer, not a millionth of one.
+    nearest = np.round(steps)
+    if abs(steps - nearest) < 1e-6:
+        steps = nearest
+
+    nchan = int(np.floor(steps)) + 1
     if nchan < 1:
         raise ValueError("Doppler shift over this observation exceeds the bandwidth, leaving no common channel grid. Pass an explicit grid via --doppler-chan-grid.")
 

--- a/tests/test_doppler.py
+++ b/tests/test_doppler.py
@@ -138,6 +138,31 @@ class TestChannelGrid(unittest.TestCase):
             assert edges.min() > min(freqs)
             assert edges.max() < max(freqs)
 
+    def test_a_shifted_grid_keeps_its_channel_count(self):
+        """One shared factor cancels out of the span, so it cannot change the count.
+
+        It used to. Multiplying ~1e9 Hz by the factor before dividing left the
+        ratio a few ULPs either side of the integer, and on the low side
+        ``floor`` charged a whole channel for the rounding -- for about half of
+        all factors, unpredictably. A cube always takes a single factor, and a
+        short track effectively does too.
+        """
+        steady, _, _ = common_channel_grid(self.ascending, np.ones(4))
+        assert steady == self.nchan - 2
+
+        rng = np.random.default_rng(0)
+        factors = np.concatenate([[1.0, 1.0000023, 0.9999977], 1 + rng.uniform(-3e-4, 3e-4, 50)])
+
+        for factor in factors:
+            for freqs in (self.ascending, self.descending):
+                nchan, chan0, width = common_channel_grid(freqs, np.full(4, factor))
+
+                assert nchan == steady, f"factor {factor!r} changed the channel count"
+                # And the guard channels still hold, against the shifted band.
+                edges = grid_frequencies(nchan, chan0, width)[[0, -1]]
+                assert edges.min() > min(freqs) * factor
+                assert edges.max() < max(freqs) * factor
+
     def test_auto_grid_shrinks_as_the_band_drifts(self):
         """A wider spread of factors must not widen the common coverage."""
         steady, _, _ = common_channel_grid(self.ascending, np.ones(4))

--- a/tests/test_doppler_image.py
+++ b/tests/test_doppler_image.py
@@ -383,11 +383,11 @@ class TestEndToEnd(unittest.TestCase):
             with fitsio.open(path) as hdul:
                 headers.append(hdul[0].header)
                 assert hdul[0].header["SPECSYS"] == FITS_SPECSYS["bary"]
-                # Guard channels mean the grid is narrower than the input band.
-                # Not a fixed count: 'auto' drops one channel at each end, and
-                # which side of the floor() in common_channel_grid a shifted
-                # grid lands on costs at most one more.
-                assert 28 <= hdul[0].header["NAXIS3"] <= 30
+                # Guard channels mean the grid is narrower than the input band,
+                # by exactly the one channel dropped at each end. This was a
+                # range: a shifted grid could land either side of the floor() in
+                # common_channel_grid and lose one more, unpredictably.
+                assert hdul[0].header["NAXIS3"] == 30
 
         # The pair must remain recombinable, i.e. be on one identical grid.
         for key in ("NAXIS3", "CRVAL3", "CDELT3", "CRPIX3", "SPECSYS"):


### PR DESCRIPTION
Closes **handover item 3**.

## The bug

`common_channel_grid` derives the output length by dividing the common span by
the channel width and flooring:

```python
nchan = int(np.floor((chanl - chan0) / width)) + 1
```

When every timestamp shares one Doppler factor — always true of a cube, and
effectively true of a short track — that factor **cancels out of the ratio**, so
the span is a whole number of channels in real arithmetic. But `chan0` and
`chanl` are ~1e9 Hz multiplied by the factor first, which leaves the division a
few ULPs either side of the integer. On the low side, `floor` charges a whole
channel for the rounding.

## It is a coin flip, not an edge case

The handover note called it occasional. Sampling 401 factors around unity on a
32-channel grid:

```
max |deviation from integer| = 4.26e-13 channels
landed BELOW the integer     = 186/401
resulting nchan              = {29: 186, 30: 215}     want: all 30
```

So roughly half of all runs produced `nchan_in - 3` instead of the intended
`nchan_in - 2`, with no way to predict which.

## The fix

Snap the ratio to the integer when it is within `1e-6` of one, before flooring.
The observed error is ~4e-13 channels, so the tolerance is orders of magnitude
clear of the noise — and a genuine drift falls *whole channels* short of the
integer, not a millionth of one. Verified: `[0.9999, 1.0001]` still trims to 29,
`[0.999, 1.001]` to 27.

## This changes output channel counts

A grid that came out one channel short now comes out at its intended width. **No
data moves** — the grid was guard-trimmed either way, and both edges stay
strictly inside the shifted band (checked for every sampled factor, in both grid
directions). `vis-mowjsub`, `im-mowjsub` and `doppler-mowjsub` are affected
identically. `CHANGES.md` records it under Fixed.

On the 256-channel bench cube, the `bary` grid goes from 253 channels to 254.

## Verification

- 93 tests pass, 1 skipped (was 92/1). Lint, format and docs clean.
- `test_a_shifted_grid_keeps_its_channel_count` sweeps 53 factors across both
  ascending and descending grids, asserting the count never depends on the
  factor and that the guard channels still hold against the shifted band.
- `test_both_cubes_land_on_the_corrected_grid` asserted `28 <= NAXIS3 <= 30`
  precisely because of this bug; it now asserts exactly 30.
- Both were checked by mutation — removing the snap fails both.
- Ran the real CLI on the Doppler path to confirm 253 → 254.

## Remaining

Handover item 4 (caracal2 coordination) is the last one, and it is external to
this repo. Still outstanding on the fitstoolz side: cutting 0.2.1 so the
`[tool.uv.sources]` git pin can come out of `pyproject.toml`.
