### PR TITLE
Honour the fit parameters both CLIs already declare

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,30 @@
 Notable changes to mowjsub. Versions before 2.0 were released under the
 project's former name, **contsub**.
 
-## Unreleased (2.0rc2)
+## Unreleased
+
+### Fixed
+
+- **`--chan-width` is honoured rather than accepted and ignored.** Both
+  `im-mowjsub` and `vis-mowjsub` declared the option and neither passed it to a
+  fitter, so it satisfied no validation check and changed no result: a run given
+  only `--chan-width` was refused for want of `--vel-width`, and a run given both
+  quietly used the velocity. `FitFunc.default_prepare` has taken either
+  throughout, so this was CLI wiring rather than a missing feature. Two related
+  changes: giving both widths is now an error rather than a silent preference for
+  one of them, and a `--chan-width` below 1 is refused, since `default_prepare`
+  bumps an even width up by one and so turned 0 into a one-channel window.
+
+- **`--fit-model scipy-median-filter` could not run in the image plane at all.**
+  FITS is big-endian by definition and `scipy.ndimage.median_filter` accepts only
+  native byte order, so on every little-endian machine the fitter reached scipy
+  with a `>f4` spectrum and got back a bare `RuntimeError: Unsupported array
+  type`, naming neither the array nor the reason. The exception escapes
+  `ContSub.fitContinuum`, so it took the whole run with it. The spectrum is
+  converted at that one call site now. The visibility plane was never affected:
+  dask-ms yields native arrays.
+
+## 2.0.0 — 2026-08-04
 
 ### Changed
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,21 @@ project's former name, **contsub**.
 
 ## Unreleased
 
+### Changed
+
+- **`im-mowjsub --sigma-clip` takes a single value, and `--automask-per-iter` is
+  gone.** Both described an iterative automasking mode that was never
+  implemented: `get_automask` does one fit and one clip, and never read the flag
+  at all. The option's `list[float]` type was not merely unused, it was unusable
+  — `PixSigmaClip` multiplies the whole list against the noise array in one
+  operation, so any count but one mis-broadcast, raising for most lengths and
+  producing a silently wrong mask when the list happened to match the spectral
+  axis. **A command line passing more than one `--sigma-clip`, or
+  `--automask-per-iter`, must drop them**; nothing that worked before stops
+  working, since one value is all that ever did. The multi-iteration example in
+  the usage docs goes with them — it also passed several `--order` and
+  `--segments` values, which have been scalars since the Stimela 3 port.
+
 ### Fixed
 
 - **`--chan-width` is honoured rather than accepted and ignored.** Both

--- a/docs/source/how-to/usage.rst
+++ b/docs/source/how-to/usage.rst
@@ -18,24 +18,16 @@ A key advantage of image-plane continuum subtraction is that it allows for robus
     im-mowjsub --output-prefix output_prefix \
                 --sigma-clip 5 \
                 --order 3 \
-                --segments 250 \
+                --vel-width 250 \
                 --ra-chunks 64 \
                 --nworkers 8 \
                 input_fits_cube.fits
+
+The mask is built by fitting an unmasked continuum first and clipping *that* residual, so it works on a cube which still holds its continuum.
 
 However, if the line emission is known, a binary mask can be provided to the ``--mask-image`` option. In this case, the ``--sigma-clip`` parameter will be ignored (if set.)
 
-:command:`im-mowjsub` also allows the user to specify multiple ``--sigma-clip``, ``--order`` and ``--segments`` parameters. This allows the user to do the continuum subtraction in multiple iterations, each time using a different set of parameters. The advantage of this is that the user can start with a large ``--sigma-clip`` and wide ``--segments`` values to remove the most significant line emission, and then gradually decrease both to remove smaller line emission features. When using this mode, the ``--segments`` and ``--order`` must have the same length. Here's an example
-
-.. code-block:: bash
-
-    im-mowjsub --output-prefix output_prefix \
-                --sigma-clip 5 5 3 \
-                --order 3 2 2 \
-                --segments 400 300 250 \
-                --ra-chunks 64 \
-                --nworkers 8 \
-                input_fits_cube.fits
+The width of the fit window can be given either as a velocity, with ``--vel-width``, or directly in channels, with ``--chan-width``. Give one or the other, not both. ``--segments`` is the former name of ``--vel-width`` and is kept only for compatibility.
 
 
 :command:`vis-mowjsub`

--- a/src/mowjsub/fitfuncs.py
+++ b/src/mowjsub/fitfuncs.py
@@ -324,6 +324,19 @@ class FitMedFilterFast(FitFunc):
         else:
             data_filled = data
 
+        # scipy's rank filters accept only native byte order, and raise a bare
+        # `RuntimeError: Unsupported array type` on anything else -- naming
+        # neither the array nor the reason. FITS is big-endian by definition, so
+        # `zds_from_fits` hands back a `>f4` cube on every little-endian machine
+        # there is, and this fitter could not run in the image plane at all.
+        # Converted here, per spectrum, rather than over the cube at read time:
+        # this is the only consumer that cannot take the array as the file
+        # stores it, and byteswapping whole cubes for it would cost every other
+        # fitter a copy. `asarray` is a no-op when the order is already native,
+        # so the visibility plane (where dask-ms yields native arrays) is
+        # untouched.
+        data_filled = np.asarray(data_filled, dtype=data_filled.dtype.newbyteorder("="))
+
         # Use scipy.ndimage.median_filter for speed
         filtered = median_filter(data_filled, size=self.chanwidth, mode="reflect")
 

--- a/src/mowjsub/fitfuncs.py
+++ b/src/mowjsub/fitfuncs.py
@@ -13,6 +13,20 @@ from .exceptions import BadFitError
 
 log = logging.getLogger(LOGGER)
 
+#: Fit models that cannot run without an ``order``.
+ORDER_MODELS = ("b-spline", "spline", "polynomial")
+
+#: Fit models that cannot run without a fit-window width -- either
+#: ``velwidth`` (physical) or ``chanwidth`` (in channels). ``default_prepare``
+#: derives the second from the first when both are offered, so a caller need
+#: only supply one, but it raises when handed neither.
+#:
+#: Both lists live here rather than in the parsers because the two entry points
+#: enforce the same requirement and had already drifted once: ``--chan-width``
+#: was accepted by both and passed on by neither, so it satisfied no check and
+#: reached no fitter.
+WIDTH_MODELS = ("b-spline", "spline", "median-filter", "scipy-median-filter")
+
 
 class FitFunc:
     def __init__(

--- a/src/mowjsub/parser/im_mowjsub.py
+++ b/src/mowjsub/parser/im_mowjsub.py
@@ -14,6 +14,8 @@ from pydantic import Field
 
 from mowjsub import BIN, set_logger
 from mowjsub.fitfuncs import (
+    ORDER_MODELS,
+    WIDTH_MODELS,
     FitBSpline,
     FitGCVSpline,
     FitMedFilter,
@@ -60,13 +62,20 @@ def runit(opts):
     if opts.overwrite is False and (outcont.exists() or outline.exists()):
         raise RuntimeError("At least one output file exists, but --no-overwrite has been set. Unset it to proceed.")
 
-    if opts.fit_model in ("b-spline", "spline", "polynomial") and opts.order is None:
+    if opts.fit_model in ORDER_MODELS and opts.order is None:
         raise RuntimeError(f"The parameter 'order' is required for fit-model={opts.fit_model}.")
 
     velwidth = opts.vel_width or opts.segments
+    chanwidth = opts.chan_width
 
-    if opts.fit_model in ("b-spline", "spline", "median-filter", "scipy-median-filter") and velwidth is None:
-        raise RuntimeError(f"The parameter 'vel-width' (or legacy 'segments') is required for fit-model={opts.fit_model}.")
+    if velwidth is not None and chanwidth is not None:
+        raise RuntimeError("--vel-width and --chan-width both set the width of the fit window, in different units. Give one, not both.")
+
+    if chanwidth is not None and chanwidth < 1:
+        raise RuntimeError(f"--chan-width={chanwidth} is not a channel count. It must be at least 1.")
+
+    if opts.fit_model in WIDTH_MODELS and velwidth is None and chanwidth is None:
+        raise RuntimeError(f"The parameter 'vel-width' (or legacy 'segments') or 'chan-width' is required for fit-model={opts.fit_model}.")
 
     if opts.ra_chunks < 0:
         raise RuntimeError("The parameter 'ra-chunks' cannot be negative. Set it to zero to disable chunking.")
@@ -113,13 +122,13 @@ def runit(opts):
     futures = []
 
     if opts.fit_model in ["spline", "b-spline"]:
-        fitfunc = FitBSpline(xspec, order=opts.order, velwidth=velwidth, fit_tol=opts.cont_fit_tol)
+        fitfunc = FitBSpline(xspec, order=opts.order, velwidth=velwidth, chanwidth=chanwidth, fit_tol=opts.cont_fit_tol)
     elif opts.fit_model == "polynomial":
         fitfunc = FitPolynomial(xspec, order=opts.order, fit_tol=opts.cont_fit_tol)
     elif opts.fit_model == "median-filter":
-        fitfunc = FitMedFilter(xspec, velwidth=velwidth, fit_tol=opts.cont_fit_tol)
+        fitfunc = FitMedFilter(xspec, velwidth=velwidth, chanwidth=chanwidth, fit_tol=opts.cont_fit_tol)
     elif opts.fit_model == "scipy-median-filter":
-        fitfunc = FitMedFilterFast(xspec, velwidth=velwidth, fit_tol=opts.cont_fit_tol)
+        fitfunc = FitMedFilterFast(xspec, velwidth=velwidth, chanwidth=chanwidth, fit_tol=opts.cont_fit_tol)
     elif opts.fit_model == "gcv-spline":
         fitfunc = FitGCVSpline(xspec, fit_lam=opts.gcv_lambda, fit_tol=opts.cont_fit_tol)
     else:
@@ -228,8 +237,14 @@ def im_mowjsub(
         ),
     ),
     order: int | None = Field(None, description="Order of spline/polynomial or number of top coefficients to use for DCT reconstruction"),
-    vel_width: float | None = Field(None, description="Width of spline segments or median filter window in km/s."),
-    chan_width: int | None = Field(None, description="Width of spline segments or median filter window in number of channels."),
+    vel_width: float | None = Field(None, description="Width of spline segments or median filter window in km/s. Give this or --chan-width, not both."),
+    chan_width: int | None = Field(
+        None,
+        description=(
+            "Width of spline segments or median filter window in number of channels. The alternative to --vel-width, for a caller that "
+            "wants the window fixed in channels rather than converted from a velocity against the band centre. Give one or the other, not both."
+        ),
+    ),
     gcv_lambda: float | None = Field(
         None,
         description=(

--- a/src/mowjsub/parser/im_mowjsub.py
+++ b/src/mowjsub/parser/im_mowjsub.py
@@ -226,8 +226,13 @@ def im_mowjsub(
     input_image: Path = Field(..., description="Input image"),
     output_prefix: str | None = Field(None, description="Name of ouput image"),
     mask_image: Path | None = Field(None, description="Mask image"),
-    sigma_clip: list[float] | None = Field(None, description="Sigma clip for each iteration. Only required if mask-image is not given."),
-    automask_per_iter: bool = Field(False, description="Generate a new mask per iteration."),
+    sigma_clip: float | None = Field(
+        None,
+        description=(
+            "Sigma-clipping level for the automatic mask, which is built by fitting an unmasked continuum first and clipping that residual -- "
+            "so it works on a cube that still holds its continuum. Only used if --mask-image is not given."
+        ),
+    ),
     fit_model: FIT_MODELS = Field(
         "b-spline",
         description=(

--- a/src/mowjsub/parser/vis_mowjsub.py
+++ b/src/mowjsub/parser/vis_mowjsub.py
@@ -16,6 +16,8 @@ from tqdm.dask import TqdmCallback
 
 from mowjsub import BIN, set_logger
 from mowjsub.fitfuncs import (
+    ORDER_MODELS,
+    WIDTH_MODELS,
     FitBSpline,
     FitGCVSpline,
     FitMedFilter,
@@ -50,15 +52,22 @@ def runit(opts):
     fieldid = opts.field_id
     chunksize = opts.row_chunks
     velwidth = opts.vel_width or opts.segments
+    chanwidth = opts.chan_width
     method = opts.fit_model
     order = opts.order
     nworkers = opts.nworkers
 
-    if method in ("spline", "b-spline", "polynomial") and order is None:
+    if method in ORDER_MODELS and order is None:
         raise RuntimeError(f"The parameter 'order' is required for fit-model={method}.")
 
-    if method in ("spline", "b-spline", "median-filter", "scipy-median-filter") and velwidth is None:
-        raise RuntimeError(f"The parameter 'vel-width' is required for fit-model={method}.")
+    if velwidth is not None and chanwidth is not None:
+        raise RuntimeError("--vel-width and --chan-width both set the width of the fit window, in different units. Give one, not both.")
+
+    if chanwidth is not None and chanwidth < 1:
+        raise RuntimeError(f"--chan-width={chanwidth} is not a channel count. It must be at least 1.")
+
+    if method in WIDTH_MODELS and velwidth is None and chanwidth is None:
+        raise RuntimeError(f"The parameter 'vel-width' (or legacy 'segments') or 'chan-width' is required for fit-model={method}.")
 
     doppler_frame = opts.doppler_frame
     # Fail before the fit rather than after it: regridding changes the channel
@@ -95,13 +104,13 @@ def runit(opts):
     futures = []
 
     if method in ("spline", "b-spline"):
-        fitfunc = FitBSpline(xspec, order=order, velwidth=velwidth, fit_tol=cont_tol)
+        fitfunc = FitBSpline(xspec, order=order, velwidth=velwidth, chanwidth=chanwidth, fit_tol=cont_tol)
     elif method == "polynomial":
         fitfunc = FitPolynomial(xspec, order=order, fit_tol=cont_tol)
     elif method == "median-filter":
-        fitfunc = FitMedFilter(xspec, velwidth=velwidth, fit_tol=cont_tol)
+        fitfunc = FitMedFilter(xspec, velwidth=velwidth, chanwidth=chanwidth, fit_tol=cont_tol)
     elif method == "scipy-median-filter":
-        fitfunc = FitMedFilterFast(xspec, velwidth=velwidth, fit_tol=cont_tol)
+        fitfunc = FitMedFilterFast(xspec, velwidth=velwidth, chanwidth=chanwidth, fit_tol=cont_tol)
     elif method == "gcv-spline":
         fitfunc = FitGCVSpline(xspec, fit_lam=opts.gcv_lambda, fit_tol=cont_tol)
     else:
@@ -158,7 +167,11 @@ def runit(opts):
         # bandpass structure it models is stationary; only the residual is moved
         # onto the Doppler-corrected grid.
         source_vel = opts.doppler_source_vel
-        regrid_ds, freqs_out, chanwidth = doppler_regrid_dataset(
+        # `grid_chanwidth`, not `chanwidth`: this is the output grid's channel
+        # width in Hz, a different quantity from the fit-window width in
+        # channels above, which is still needed nowhere below but would be
+        # silently clobbered by the shorter name.
+        regrid_ds, freqs_out, grid_chanwidth = doppler_regrid_dataset(
             msds,
             ms,
             line_data,
@@ -176,7 +189,7 @@ def runit(opts):
         with TqdmCallback(desc="Writing Doppler-corrected line data"):
             da.compute(writes)
 
-        finalise_regridded_ms(ms, ms_name, spwid, freqs_out, chanwidth, doppler_frame)
+        finalise_regridded_ms(ms, ms_name, spwid, freqs_out, grid_chanwidth, doppler_frame)
         log.info(f"UV plane continuum subtraction completed. Doppler-corrected line data written to column '{output_column}' in {ms_name}.")
     elif opts.output_ms:
         # A new MS needs every row column plus the subtables, not just the line
@@ -244,8 +257,14 @@ def vis_mowjsub(
         ),
     ),
     order: int | None = Field(None, description="Order of spline/polynomial or number of top coefficients to use for DCT reconstruction"),
-    vel_width: float | None = Field(None, description="Width of spline segments or median filter window in km/s."),
-    chan_width: int | None = Field(None, description="Width of spline segments or median filter window in number of channels."),
+    vel_width: float | None = Field(None, description="Width of spline segments or median filter window in km/s. Give this or --chan-width, not both."),
+    chan_width: int | None = Field(
+        None,
+        description=(
+            "Width of spline segments or median filter window in number of channels. The alternative to --vel-width, for a caller that "
+            "wants the window fixed in channels rather than converted from a velocity against the band centre. Give one or the other, not both."
+        ),
+    ),
     gcv_lambda: float | None = Field(
         None,
         description=(

--- a/src/mowjsub/utils.py
+++ b/src/mowjsub/utils.py
@@ -42,16 +42,23 @@ log = logging.getLogger(LOGGER)
 
 
 def get_automask(cube, fitfunc, sigma_clip):
-    """
-    Generate a binary mask by sigma-thresholding the input cube
+    """Generate a binary mask by sigma-thresholding the input cube.
+
+    An unmasked continuum is fitted first and the *residual* is what gets
+    clipped, so this works on a cube that still holds its continuum -- unlike a
+    mask made by a source finder run over the same cube, which would find the
+    continuum sources in every channel.
 
     Args:
-        xspec (Array): Spectral coordinates
-        cube (Array): Data cdube
-        sigma_clip(float): Sigma clip level
+        cube (Array): Data cube.
+        fitfunc (FitFunc): Fitter used for that first, unmasked continuum.
+        sigma_clip (float): Sigma clip level.
 
     Returns:
-        Array : Binary mask (False is masked, True is not)
+        Array: Binary mask, ``True`` where a channel is excluded from the fit --
+        the convention ``FitFunc.fit`` reads (it fits ``self.freqs[~mask]``).
+        Note this is the opposite of what the sigma clip itself returns, which
+        is why the result is inverted on the way out.
     """
 
     log.info("Creating binary mask as requested")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -270,3 +270,58 @@ class TestChanWidthIsHonoured(unittest.TestCase):
 
         with fitsio.open(f"{other}-cont.fits") as a, fitsio.open(f"{reference}-cont.fits") as b:
             assert not np.array_equal(a[0].data, b[0].data)
+
+
+class TestSigmaClipIsScalar(unittest.TestCase):
+    """``--sigma-clip`` takes one value, and the automask reaches the fit.
+
+    It used to be a ``list[float]`` ("one per iteration"), with a companion
+    ``--automask-per-iter``, but no iteration was ever implemented:
+    ``get_automask`` does one fit and one clip, and never read the flag.
+    ``PixSigmaClip`` multiplies the whole list against the noise array in a
+    single operation, so anything but one value mis-broadcast -- usually a
+    crash, and a silently wrong mask when the list happened to be as long as
+    the spectral axis.
+    """
+
+    def setUp(self):
+        self.tmpdir = Path(tempfile.mkdtemp())
+        self.cube = self.tmpdir / "cube.fits"
+        _write_cube(self.cube)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def _im(self, *args):
+        return CliRunner().invoke(im_command, [str(self.cube), *args], catch_exceptions=True)
+
+    def test_a_single_value_is_accepted(self):
+        result = self._im("--fit-model", "scipy-median-filter", "--vel-width", "15", "--sigma-clip", "3", "--output-prefix", str(self.tmpdir / "out"))
+
+        assert result.exit_code == 0, result.exception
+
+    def test_a_second_value_is_a_usage_error(self):
+        """Not a traceback from inside numpy's broadcasting, which is what a
+        list-typed option gave for every count the clipper could not use."""
+        result = self._im("--fit-model", "scipy-median-filter", "--vel-width", "15", "--sigma-clip", "5", "3", "--output-prefix", str(self.tmpdir / "out"))
+
+        assert result.exit_code == 2, result.output
+
+    def test_automask_per_iter_is_gone(self):
+        assert "--automask-per-iter" not in CliRunner().invoke(im_command, ["--help"]).output
+
+    def test_the_automask_changes_the_fit(self):
+        """Guards the acceptance test above: an option that parsed but did not
+        reach `get_automask` would still exit 0.
+
+        The cube carries a one-channel line, so clipping it out of the fit has
+        to move the continuum model.
+        """
+        masked, unmasked = self.tmpdir / "masked", self.tmpdir / "unmasked"
+
+        for prefix, extra in ((masked, ("--sigma-clip", "3")), (unmasked, ())):
+            result = self._im("--fit-model", "scipy-median-filter", "--vel-width", "15", *extra, "--output-prefix", str(prefix))
+            assert result.exit_code == 0, (prefix, result.exception)
+
+        with fitsio.open(f"{masked}-cont.fits") as a, fitsio.open(f"{unmasked}-cont.fits") as b:
+            assert not np.array_equal(a[0].data, b[0].data)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,6 +17,7 @@ import astropy.io.fits as fitsio
 import numpy as np
 from click.testing import CliRunner
 
+from mowjsub import utils
 from mowjsub.parser._cli import make_command
 from mowjsub.parser.doppler_mowjsub import command as doppler_command
 from mowjsub.parser.doppler_mowjsub import doppler_mowjsub
@@ -30,6 +31,34 @@ COMMANDS = {
     "vis-mowjsub": (vis_command, ["--output-column", "LINE", "--fit-model", "polynomial", "--order", "3"]),
     "doppler-mowjsub": (doppler_command, ["--input-column", "A", "--output-column", "B", "--doppler-frame", "bary"]),
 }
+
+
+#: A small cube with a real spectral WCS, and enough structure that a continuum
+#: fit has something to do -- a flat cube would model identically at any window
+#: width, so the width tests below would pass however the option were wired.
+_CUBE_NCHAN = 64
+_CUBE_F0 = 1.36e9
+_CUBE_DF = 6.5e3
+#: Channel frequencies in Hz, as `utils.chans_in_velwidth` wants them.
+_CUBE_FREQS = _CUBE_F0 + _CUBE_DF * np.arange(_CUBE_NCHAN)
+
+
+def _write_cube(path, npix=3):
+    """Write that cube: noise on a sloping continuum, with a one-channel line."""
+    header = fitsio.Header()
+    header["CTYPE1"], header["CRVAL1"], header["CDELT1"], header["CRPIX1"], header["CUNIT1"] = "RA---SIN", 201.36506, -1.0 / 3600, npix / 2, "deg"
+    header["CTYPE2"], header["CRVAL2"], header["CDELT2"], header["CRPIX2"], header["CUNIT2"] = "DEC--SIN", -43.01911, 1.0 / 3600, npix / 2, "deg"
+    header["CTYPE3"], header["CRVAL3"], header["CDELT3"], header["CRPIX3"], header["CUNIT3"] = "FREQ", _CUBE_F0, _CUBE_DF, 1.0, "Hz"
+    header["RESTFRQ"] = 1.42040575e9
+    header["SPECSYS"] = "TOPOCENT"
+    header["BUNIT"] = "Jy/beam"
+
+    rng = np.random.default_rng(20260804)
+    data = rng.normal(scale=0.1, size=(_CUBE_NCHAN, npix, npix)).astype(np.float32)
+    data += np.linspace(1.0, 2.0, _CUBE_NCHAN, dtype=np.float32)[:, None, None]
+    data[_CUBE_NCHAN // 2] += 10.0
+
+    fitsio.PrimaryHDU(data, header=header).writeto(path, overwrite=True)
 
 
 class TestMissingInputs(unittest.TestCase):
@@ -142,3 +171,102 @@ class TestMakeCommand(unittest.TestCase):
             result = CliRunner().invoke(command, ["--version"])
             assert result.exit_code == 0, name
             assert result.output.strip(), name
+
+
+class TestChanWidthIsHonoured(unittest.TestCase):
+    """``--chan-width`` reaches the fitter.
+
+    Both entry points accepted the option and neither passed it on. It
+    therefore satisfied no validation check and reached no ``FitFunc``: a run
+    given only ``--chan-width`` was refused for want of ``--vel-width``, and a
+    run given both quietly used the velocity. ``FitFunc.default_prepare`` has
+    taken either throughout -- ``test_main.TestFitsFunc`` pins that the two
+    agree -- so what was missing is CLI wiring, which is why this lives here
+    and not beside those.
+    """
+
+    def setUp(self):
+        self.tmpdir = Path(tempfile.mkdtemp())
+        self.cube = self.tmpdir / "cube.fits"
+        _write_cube(self.cube)
+        # An empty directory is enough for vis-mowjsub: the width checks run
+        # before the MS is opened, the same trick TestOutputMsIsNotTheInput uses.
+        self.ms = self.tmpdir / "input.ms"
+        self.ms.mkdir()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def _im(self, *args):
+        return CliRunner().invoke(im_command, [str(self.cube), *args], catch_exceptions=True)
+
+    def _vis(self, *args):
+        return CliRunner().invoke(vis_command, [str(self.ms), "--output-column", "LINE", *args], catch_exceptions=True)
+
+    def test_chan_width_alone_satisfies_the_width_requirement(self):
+        for name, result in (
+            ("im-mowjsub", self._im("--fit-model", "scipy-median-filter", "--chan-width", "5", "--output-prefix", str(self.tmpdir / "out"))),
+            ("vis-mowjsub", self._vis("--fit-model", "scipy-median-filter", "--chan-width", "5")),
+        ):
+            assert "is required for fit-model" not in str(result.exception), name
+
+    def test_neither_width_is_still_refused(self):
+        for name, result in (
+            ("im-mowjsub", self._im("--fit-model", "scipy-median-filter")),
+            ("vis-mowjsub", self._vis("--fit-model", "scipy-median-filter")),
+        ):
+            assert "is required for fit-model" in str(result.exception), name
+
+    def test_both_widths_together_are_refused(self):
+        """They set the same window in different units, and `default_prepare`
+        silently prefers the velocity -- so accepting both would mean ignoring
+        one of two values the caller stated explicitly."""
+        for name, result in (
+            ("im-mowjsub", self._im("--fit-model", "scipy-median-filter", "--vel-width", "15", "--chan-width", "5")),
+            ("vis-mowjsub", self._vis("--fit-model", "scipy-median-filter", "--vel-width", "15", "--chan-width", "5")),
+        ):
+            assert "Give one, not both" in str(result.exception), name
+
+    def test_a_chan_width_below_one_is_refused(self):
+        """`default_prepare` bumps an even width up by one, which turns 0 into a
+        one-channel window and leaves a negative width negative."""
+        for name, result in (
+            ("im-mowjsub", self._im("--fit-model", "scipy-median-filter", "--chan-width", "0")),
+            ("vis-mowjsub", self._vis("--fit-model", "scipy-median-filter", "--chan-width", "0")),
+        ):
+            assert "is not a channel count" in str(result.exception), name
+
+    def test_chan_width_gives_the_same_continuum_as_the_equivalent_vel_width(self):
+        """The end-to-end check that the value is used, not merely accepted.
+
+        `scipy-median-filter` rather than a spline: `FitBSpline` jitters its
+        knots and exposes no seed on the command line, so a CLI-level equality
+        check on it would be flaky for reasons that have nothing to do with the
+        width.
+        """
+        chanwidth = utils.chans_in_velwidth(_CUBE_FREQS, 15 * 1e3)
+
+        by_vel = self.tmpdir / "by-vel"
+        by_chan = self.tmpdir / "by-chan"
+
+        for prefix, width in ((by_vel, ("--vel-width", "15")), (by_chan, ("--chan-width", str(chanwidth)))):
+            result = self._im("--fit-model", "scipy-median-filter", *width, "--output-prefix", str(prefix))
+            assert result.exit_code == 0, (prefix, result.exception)
+
+        with fitsio.open(f"{by_vel}-cont.fits") as vel, fitsio.open(f"{by_chan}-cont.fits") as chan:
+            np.testing.assert_array_equal(chan[0].data, vel[0].data)
+
+    def test_an_unconverted_chan_width_would_have_failed_that_check(self):
+        """Guards the test above: a different width must give a different fit,
+        or the equality it asserts would hold however the option were wired.
+        """
+        other = self.tmpdir / "other"
+        result = self._im("--fit-model", "scipy-median-filter", "--chan-width", "3", "--output-prefix", str(other))
+        assert result.exit_code == 0, result.exception
+
+        reference = self.tmpdir / "reference"
+        result = self._im("--fit-model", "scipy-median-filter", "--vel-width", "15", "--output-prefix", str(reference))
+        assert result.exit_code == 0, result.exception
+
+        with fitsio.open(f"{other}-cont.fits") as a, fitsio.open(f"{reference}-cont.fits") as b:
+            assert not np.array_equal(a[0].data, b[0].data)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -83,6 +83,24 @@ class TestFitsFunc(unittest.TestCase):
 
         assert np.allclose(baseline_vel, baseline_chan, atol=1e-6)
 
+    def test_median_filter_fast_accepts_a_big_endian_spectrum(self):
+        """FITS is big-endian, and scipy's rank filters take only native order.
+
+        `zds_from_fits` hands back the cube in the order the file stores it, so
+        on every little-endian machine this fitter was given a `>f4` spectrum
+        and scipy raised a bare `RuntimeError: Unsupported array type`, naming
+        neither the array nor the reason. `--fit-model scipy-median-filter`
+        could therefore not run in the image plane at all. The visibility plane
+        never saw it: dask-ms yields native arrays.
+        """
+        big_endian = self.data.astype(self.data.dtype.newbyteorder(">"))
+        assert not big_endian.dtype.isnative, "this test needs a non-native array to be about anything"
+
+        baseline_native = FitMedFilterFast(self.freqs, velwidth=self.velwidth).fit(self.data, mask=self.mask, weights=None)
+        baseline_big = FitMedFilterFast(self.freqs, velwidth=self.velwidth).fit(big_endian, mask=self.mask, weights=None)
+
+        np.testing.assert_allclose(baseline_big, baseline_native)
+
     def test_polynomial(self):
         baseline_func = FitPolynomial(self.freqs, order=3)
         baseline = baseline_func.fit(self.data, mask=self.mask, weights=None)


### PR DESCRIPTION
Three defects in the same family: parameters and models that the command line
advertises but that do not reach, or cannot survive, the fit. Found while
wiring `im-mowjsub` into caracal2's `line` worker.

One commit each, in dependency order — the first is what lets the second's
tests use `scipy-median-filter`.

### `--fit-model scipy-median-filter` could not run in the image plane at all

FITS is big-endian by definition, `zds_from_fits` hands the cube back in the
order the file stores it, and `scipy.ndimage.median_filter` accepts only native
byte order. On every little-endian machine the fitter reached scipy with a
`>f4` spectrum and got back a bare

    RuntimeError: Unsupported array type

naming neither the array nor the reason, and the exception escapes
`ContSub.fitContinuum` rather than marking the spectrum bad, so it took the
whole run with it. Reproduced on `main` at 8f4b236 with an ordinary 3×3×64
cube.

Converted per spectrum at the one call site that cannot take the array as the
file stores it, rather than byteswapping in the reader: every other fitter is
happy with big-endian, and a read-time conversion would cost them all a copy of
the cube. `asarray` is a no-op on an already-native array, so the visibility
plane — where dask-ms yields native arrays — is untouched. `FitDCT` runs
`FitMedFilterFast` internally and was broken the same way.

### `--chan-width` was accepted by both entry points and passed on by neither

So it satisfied no validation check and reached no `FitFunc`: a run given only
`--chan-width` was refused for want of `--vel-width`, and a run given both
quietly fitted at the velocity. `FitFunc.default_prepare` has taken either
throughout and `test_main.TestFitsFunc` already pins that the two agree — what
was missing is CLI wiring, which is why the new tests drive the commands.

Two behaviours follow from making the option real: giving both widths is now an
error rather than a silent preference for one of two explicitly stated values,
and a `--chan-width` below 1 is refused, since `default_prepare` bumps an even
width up by one and so turned 0 into a one-channel window.

`ORDER_MODELS`/`WIDTH_MODELS` move to `fitfuncs`, beside the fitters whose
requirements they describe — the two entry points enforced the same rule from
two copies, which is how they came to disagree here in the first place.

### `--sigma-clip` is now a single value, and `--automask-per-iter` is gone

**Breaking, in the narrow sense that only broken command lines break.** Both
parameters described an iterative automasking mode that was never implemented:
`get_automask` fits one continuum, clips its residual once, and never reads the
flag. The docstring has said `sigma_clip(float)` throughout while the CLI
declared `list[float]`.

The list type was not merely unused, it was unusable — `PixSigmaClip` applies
the level as `np.abs(sm_data) < self.n * sigma`, one operation over the whole
array, so a list of n values broadcasts against the spectral axis instead of
iterating. Every count but one raised, except a list exactly as long as the
spectral axis, which produced a per-channel threshold nobody asked for and no
error.

Narrowed to what works rather than implementing the loop. The usage docs lose
their multi-iteration example with it; that example also passed several
`--order` and `--segments` values, which have been scalars since the Stimela 3
port, so the command it showed could not be run either.

### Notes for review

- `CHANGES.md` gains a new `## Unreleased` section and the old
  `## Unreleased (2.0rc2)` is retitled `## 2.0.0 — 2026-08-04`. 2.0.0 was cut
  from exactly that content — the release commit touched only `pyproject.toml`
  and `uv.lock` — so this avoids a second, older "Unreleased". Say the word if
  you would rather it stayed as it was.
- `vis_mowjsub.runit` renames the Doppler path's local `chanwidth` to
  `grid_chanwidth`. That one is the output grid's channel width in Hz, and the
  fit-window width in channels now shares the function.
- Downstream: dosho's generated `im-mowjsub.yaml` declares `sigma-clip` as
  `List[float]` with `repeat_list: true`, and carries `automask-per-iter`. It
  needs regenerating once this lands, and caracal2's `line` worker then passes
  a scalar instead of a one-element list.

`uv run pytest`: 145 passed, 1 skipped. `ruff check` and `ruff format --check`
clean.